### PR TITLE
feat(v2.2): header & column styling, formats, freeze pane, multi-sheet API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to `kolay/xlsx-stream` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — styling & multi-sheet (v2.2)
+
+- **`StyleRegistry`** — internal helper that emits `xl/styles.xml` on demand,
+  deduplicates fonts, fills, number formats, and cellXfs by value so the
+  same preset registered twice reuses the same style id.
+- **`setHeaderStyle($options)`** — bold, fill color, text color, font size on
+  the header row. Re-callable between `newSheet()` calls so each sheet can
+  have its own header look.
+- **`setColumnFormat($col, $presetOrCode)`** — named presets (`date`,
+  `datetime`, `datetime_iso`, `time`, `integer`, `decimal`, `percent`,
+  `currency_try`, `currency_usd`, `currency_eur`, `currency_gbp`) or any
+  raw Excel format code. String cells are unaffected; numeric and DateTime
+  cells in formatted columns are stamped with the column's style id.
+- **`clearColumnFormats()`** — resets all column-level formats and widths.
+  Useful between `newSheet()` calls when the next sheet has a different
+  column layout.
+- **`freezeFirstRow()` / `freezeRowsAndColumns(rows, columns)`** — pin the
+  header row and/or the first N columns while scrolling.
+- **`enableAutoFilter()`** — emit Excel's filter dropdowns on the header row
+  with an automatically computed range.
+- **`setColumnWidths([col => width])`** — explicit per-column widths.
+- **`setAutoColumnWidth()`** — header-based heuristic with format awareness:
+  the registered column format dictates a sensible minimum width (currency
+  ≥ 14, datetime ≥ 20, date ≥ 12, percent ≥ 10) so values like ₺50,000.00
+  no longer render as `####`.
+- **`newSheet($name, $headers = null)`** — true multi-sheet workbooks with
+  custom sheet names, not just the auto-split fallback at 1,048,576 rows.
+  Optional `$headers` swaps the header row for the new sheet.
+
+### Changed
+
+- `xl/styles.xml` is now emitted at `finishFile()` instead of `startFile()`
+  so styles registered between `newSheet()` calls are still captured.
+- Configuration setters (`setHeaderStyle`, `setColumnFormat`,
+  `setColumnWidths`, `setAutoColumnWidth`, `freezeRowsAndColumns`,
+  `enableAutoFilter`) only refuse to run after `finishFile()` — they can
+  be called any time before close, including between `newSheet()` calls.
+- `BaseXlsxWriter::buildRowXml()` branches on a hoisted `$hasColumnStyles`
+  flag so the unstyled hot path matches v2.1's per-cell cost (1M rows
+  local: 161K rows/s plain vs 168K v2.1 baseline). Styled exports add
+  ~2-3% throughput overhead and ~3% file-size overhead from the `s="N"`
+  cell attributes.
+
+### Performance vs v1.x baseline (May 2026 re-measurement)
+
+- **S3 throughput**: ~2-3× faster across the board for ≥50K rows
+  (1M rows: 95K rows/s vs 43K, 4.5M: 107K rows/s vs 46K). Most of the
+  win comes from updated `aws/aws-sdk-php` (3.379+) and a faster network
+  on the measurement machine; the multipart-upload code path is unchanged.
+- **Local throughput**: ~5-10% slower than the September 2025 v1.x
+  numbers, the cost of v2.0+ per-cell type detection (boolean cells,
+  `DateTimeInterface` → serial date, big-integer-string preservation).
+- **Memory**: unchanged — local stays at 0-2 MB constant, S3 keeps the
+  same sawtooth pattern as the buffer fills and flushes per part.
+
 ## [2.1.0] — 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,52 @@ Most PHP Excel libraries (PHPSpreadsheet, Spout, Laravel Excel) have critical li
 
 ## Performance Comparison
 
-### Comprehensive Benchmark Results (September 2025)
+### Latest Benchmark — v2.2 (May 2026)
+
+Re-measured on an Apple Silicon laptop with PHP 8.2.28 and AWS SDK
+3.379 against the same `xlsx-test-package` bucket in `us-east-2`. The
+workload is identical to the v1.x baseline below (8 columns,
+mixed types, compression level 1).
+
+| Rows | Local Speed | Local Time | S3 Speed | S3 Memory | S3 Time | File Size |
+|------|-------------|------------|----------|-----------|---------|-----------|
+| 100 | 33,784 rows/s | 0.00s | 106 rows/s | 0 MB | 0.94s | 0.01 MB |
+| 500 | 153,942 rows/s | 0.00s | 481 rows/s | 0 MB | 1.04s | 0.02 MB |
+| 1,000 | 152,792 rows/s | 0.01s | 875 rows/s | 0 MB | 1.14s | 0.04 MB |
+| 5,000 | 160,639 rows/s | 0.03s | 3,342 rows/s | 0 MB | 1.50s | 0.2 MB |
+| 10,000 | 163,765 rows/s | 0.06s | 4,726 rows/s | 0 MB | 2.12s | 0.4 MB |
+| 25,000 | 173,144 rows/s | 0.14s | 11,357 rows/s | 0 MB | 2.20s | 1 MB |
+| 50,000 | 175,682 rows/s | 0.28s | 20,014 rows/s | 2 MB | 2.50s | 2 MB |
+| 100,000 | 175,130 rows/s | 0.57s | 22,372 rows/s | 4 MB | 4.47s | 4 MB |
+| 250,000 | 170,788 rows/s | 1.46s | 62,340 rows/s | 12 MB (±6) | 4.01s | 10 MB |
+| 500,000 | 171,361 rows/s | 2.92s | 83,525 rows/s | 20 MB (±18) | 5.99s | 20 MB |
+| 750,000 | 168,742 rows/s | 4.44s | 93,753 rows/s | 30 MB (±26) | 8.00s | 30 MB |
+| 1,000,000 | 161,250 rows/s | 6.20s | 95,070 rows/s | 40 MB (±38) | 10.52s | 40 MB |
+| 1,500,000 | 168,616 rows/s | 8.90s | 103,311 rows/s | 60 MB (±58) | 14.52s | 60 MB |
+| 2,000,000 | 166,369 rows/s | 12.02s | 95,629 rows/s | 79 MB (±77) | 20.91s | 79 MB |
+| 3,000,000 | – | – | 105,291 rows/s | 119 MB (±117) | 28.49s | 119 MB |
+| 4,000,000 | – | – | 106,815 rows/s | 158 MB (±156) | 37.45s | 158 MB |
+| 4,500,000 | – | – | 106,715 rows/s | 178 MB (±178) | 42.17s | 178 MB |
+
+#### What changed since v1.x
+
+- **S3 throughput is up roughly 2–3×** for any workload above 50K rows
+  (1M: 95K rows/s vs 43K, 4.5M: 107K rows/s vs 46K). Most of the win
+  comes from updated `aws/aws-sdk-php` (3.379+) and a faster network on
+  the measurement machine — the multipart-upload code path itself is
+  unchanged.
+- **Local throughput is ~5–10% lower** than the v1.x numbers — the cost
+  of the v2.0+ per-cell type detection (boolean cells, `DateTimeInterface`
+  → serial date, big-integer-string preservation). It's a deliberate
+  trade-off: v1.x produced silently broken cells for those types.
+- **Memory is unchanged** — local stays at 0–2 MB constant, S3 keeps the
+  same sawtooth pattern as the buffer fills and flushes per part.
+
+### Original Benchmark — v1.x (September 2025)
+
+Kept here for historical context. Different machine and PHP version, so
+direct cell-by-cell deltas reflect environment variance as well as code
+changes.
 
 | Rows | Local Speed | Local Memory | Local Time | S3 Speed | S3 Memory | S3 Time | File Size |
 |------|-------------|--------------|------------|----------|-----------|---------|-----------|
@@ -45,9 +90,9 @@ Most PHP Excel libraries (PHPSpreadsheet, Spout, Laravel Excel) have critical li
 | 1,000,000 | 182,693 rows/s | 0 MB | 5.47s | 43,215 rows/s | 40 MB (±38) | 23.14s | 40 MB |
 | 1,500,000 | 180,578 rows/s | 0 MB | 8.31s | 36,733 rows/s | 60 MB (±58) | 40.84s | 60 MB |
 | 2,000,000 | 177,012 rows/s | 0 MB | 11.30s | 51,323 rows/s | 79 MB (±77) | 38.97s | 79 MB |
-| 3,000,000 | - | - | - | 39,150 rows/s | 117 MB (±117) | 76.63s | 119 MB |
-| 4,000,000 | - | - | - | 42,500 rows/s | 160 MB (±156) | 94.12s | 158 MB |
-| 4,500,000 | - | - | - | 46,462 rows/s | 178 MB (±178) | 96.85s | 178 MB |
+| 3,000,000 | – | – | – | 39,150 rows/s | 117 MB (±117) | 76.63s | 119 MB |
+| 4,000,000 | – | – | – | 42,500 rows/s | 160 MB (±156) | 94.12s | 158 MB |
+| 4,500,000 | – | – | – | 46,462 rows/s | 178 MB (±178) | 96.85s | 178 MB |
 
 *Note: Tests with 1M+ rows automatically create multiple sheets (Excel limit: 1,048,576 rows per sheet)*  
 *Note: ± values in S3 Memory column indicate memory fluctuation during streaming due to periodic part uploads*
@@ -77,11 +122,11 @@ The ± values in S3 memory represent **normal memory fluctuation** during stream
    - Pattern: Memory oscillates between ~2MB (after upload) and ~78MB (before upload)
    - This is **completely normal** and expected behavior
 
-### Performance Highlights
+### Performance Highlights *(v2.2, May 2026)*
 
-- **Local File System**: ~180,000 rows/second with true O(1) memory
-- **S3 Streaming**: 30,000-50,000 rows/second with periodic memory fluctuation
-- **Memory Efficiency**: Local uses <2MB, S3 averages 40MB per million rows
+- **Local File System**: ~160,000–175,000 rows/second with true O(1) memory
+- **S3 Streaming**: 90,000–110,000 rows/second above 1M rows (2–3× the v1.x baseline)
+- **Memory Efficiency**: Local uses <2 MB, S3 averages 40 MB per million rows
 - **Multi-sheet Support**: Automatic sheet creation at Excel's 1,048,576 row limit
 - **Production Ready**: Successfully tested with 4.5 million rows
 
@@ -92,8 +137,8 @@ The ± values in S3 memory represent **normal memory fluctuation** during stream
 | PHPSpreadsheet | ❌ Crashes | ~8GB | Full file | Indirect |
 | Spout | ~60 sec | ~100MB+ | Full file | Indirect |
 | Laravel Excel | ~90 sec | ~500MB+ | Full file | Indirect |
-| **Kolay XLSX Stream (Local)** | ✅ **5.5 sec** | ✅ **0 MB** | ✅ **Zero** | N/A |
-| **Kolay XLSX Stream (S3)** | ✅ **23 sec** | ✅ **40MB avg** | ✅ **Zero** | ✅ **Direct** |
+| **Kolay XLSX Stream (Local)** | ✅ **6.2 sec** | ✅ **0 MB** | ✅ **Zero** | N/A |
+| **Kolay XLSX Stream (S3)** | ✅ **10.5 sec** | ✅ **40MB avg** | ✅ **Zero** | ✅ **Direct** |
 
 ## Requirements
 
@@ -389,6 +434,85 @@ $writer->writeRow([
     '+90 555 123 4567',                 // phone preserved as text
 ]);
 ```
+
+### Header & Column Styling *(v2.2+)*
+
+A small set of opt-in styling APIs that costs ~2-3% throughput and adds
+~3% to the file size. Skip them and the writer takes the v1.x-equivalent
+hot path.
+
+```php
+$writer = new SinkableXlsxWriter($sink);
+
+$writer
+    // Bold white text on dark blue, applied to the header row
+    ->setHeaderStyle([
+        'bold'  => true,
+        'fill'  => '#4F81BD',
+        'color' => '#FFFFFF',
+        'size'  => 12,
+    ])
+    // Native Excel number formats per column (1-based index)
+    ->setColumnFormat(1, 'integer')        // 12,345
+    ->setColumnFormat(5, 'currency_try')   // ₺99,999.00
+    ->setColumnFormat(6, 'percent')        // 12.50%
+    ->setColumnFormat(7, 'date')           // 2026-01-15
+    ->setColumnFormat(8, 'datetime')       // 2026-01-15 10:30:00
+    ->setColumnFormat(9, '0.000000')       // raw Excel format code
+    // Pin the header row, add filter dropdowns, auto-size columns
+    ->freezeFirstRow()
+    ->enableAutoFilter()
+    ->setAutoColumnWidth();                // header-text + format-aware
+
+$writer->startFile([
+    'Order ID', 'Customer', 'Product', 'Region',
+    'Price', 'Discount', 'Order Date', 'Created At', 'Score',
+]);
+```
+
+Available format presets: `date`, `datetime`, `datetime_iso`, `time`,
+`integer`, `decimal`, `percent`, `currency_try`, `currency_usd`,
+`currency_eur`, `currency_gbp`. Pass any other string to use a raw Excel
+format code (e.g. `0.000`, `#,##0.00 "kg"`).
+
+`setAutoColumnWidth()` derives a width from the header text length but
+also respects a per-format minimum so a `currency_try` column with the
+header `Salary` won't render as `####`. Override per column with
+`setColumnWidths([1 => 8, 2 => 30])` when you want exact control.
+
+### Manual Multi-Sheet Workbooks *(v2.2+)*
+
+`newSheet($name, $headers = null)` carves a workbook into named domain
+sheets — orthogonal to the auto-split fallback at 1,048,576 rows.
+
+```php
+$writer = new SinkableXlsxWriter($sink);
+
+$writer->setHeaderStyle(['bold' => true, 'fill' => '#4F81BD', 'color' => '#FFFFFF']);
+$writer->startFile(['ID', 'Name', 'Email']);
+
+foreach ($users->lazy() as $user) {
+    $writer->writeRow([$user->id, $user->name, $user->email]);
+}
+
+// Different header style + different columns for the next sheet
+$writer
+    ->clearColumnFormats()
+    ->setHeaderStyle(['bold' => true, 'fill' => '#9BBB59', 'color' => '#FFFFFF'])
+    ->setColumnFormat(3, 'currency_try')
+    ->newSheet('Orders', ['Order ID', 'Customer', 'Total']);
+
+foreach ($orders->lazy() as $order) {
+    $writer->writeRow([$order->id, $order->customer_id, $order->total]);
+}
+
+$stats = $writer->finishFile();
+// $stats['sheet_details'] → [['name' => 'Report', ...], ['name' => 'Orders', ...]]
+```
+
+`clearColumnFormats()` is the convenient way to drop the previous sheet's
+per-column registrations before starting a new one with a different
+column layout.
 
 ### Multi-Sheet Support (Automatic)
 

--- a/examples/s3-streaming.php
+++ b/examples/s3-streaming.php
@@ -7,18 +7,17 @@ use Kolay\XlsxStream\Sinks\S3MultipartSink;
 use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
 
 /**
- * Example: Direct S3 Streaming with Zero Disk I/O — showcases v2.2 styling.
+ * Example: Direct S3 Streaming with Zero Disk I/O — full v2.2 feature tour.
  *
- * Generates a multi-sheet workbook with header styling, column formats,
- * frozen first row, auto-filter, auto column widths, and progress reporting,
- * then streams it straight to S3 using multipart upload (no temp files).
+ * Generates a 5-sheet workbook covering every styling primitive and edge
+ * case the package exposes, then streams it straight to S3 using multipart
+ * upload (no temp files). The file is left in place so you can download
+ * and inspect it manually.
  *
- * Run with AWS env vars set, then download the file from S3 to inspect:
  *   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_BUCKET=... \
  *     AWS_DEFAULT_REGION=us-east-2 php examples/s3-streaming.php
  */
 
-// Bootstrap config from env (or .env if vlucas/phpdotenv is in the autoloader)
 if (file_exists(__DIR__.'/../.env') && class_exists(\Dotenv\Dotenv::class)) {
     \Dotenv\Dotenv::createUnsafeImmutable(__DIR__.'/..')->safeLoad();
 }
@@ -42,112 +41,238 @@ if (! getenv('AWS_ACCESS_KEY_ID') || ! getenv('AWS_SECRET_ACCESS_KEY') || $bucke
 
 function exportToS3(array $awsConfig, string $bucketName): void
 {
-    echo "Streaming styled multi-sheet workbook to S3...\n";
+    echo "Streaming styling-tour workbook to S3...\n";
     echo "Bucket: {$bucketName}\n\n";
 
     $s3 = new S3Client($awsConfig);
-    $key = 'examples/styled-'.date('Ymd-His').'.xlsx';
+    $key = 'examples/styling-tour-'.date('Ymd-His').'.xlsx';
 
     $sink = new S3MultipartSink(
         $s3,
         $bucketName,
         $key,
-        32 * 1024 * 1024, // 32 MB parts
+        32 * 1024 * 1024,
         [
             'ACL' => 'private',
-            'ContentDisposition' => 'attachment; filename="users-export.xlsx"',
+            'ContentDisposition' => 'attachment; filename="styling-tour.xlsx"',
             'Metadata' => [
                 'generated-by' => 'kolay-xlsx-stream',
                 'generated-at' => date('c'),
+                'package-version' => '2.2.0',
             ],
         ]
     );
 
     $writer = new SinkableXlsxWriter($sink);
-
-    // ─── v2.2 styling ──────────────────────────────────────────────
     $writer
         ->setCompressionLevel(1)
-        ->setBufferFlushInterval(10000)
-        // header: bold white text on dark blue
+        ->setBufferFlushInterval(10000);
+
+    $startTime = microtime(true);
+    $writer->onProgress(function (int $rows, int $bytes) use ($startTime) {
+        $rate = $rows / max(microtime(true) - $startTime, 0.001);
+        echo sprintf(
+            "    %s rows | %.2f MB | %s rows/sec\n",
+            number_format($rows),
+            $bytes / 1024 / 1024,
+            number_format(round($rate))
+        );
+    })->setProgressInterval(10000);
+
+    // ════════════════════════════════════════════════════════════════
+    // Sheet 1 — Sales (large, all major formats together)
+    // ════════════════════════════════════════════════════════════════
+    echo "[1/5] Sheet 'Sales' — 50K rows, full styling\n";
+
+    $writer
         ->setHeaderStyle([
             'bold' => true,
             'fill' => '#4F81BD',
             'color' => '#FFFFFF',
+            'size' => 12,
         ])
-        // column number formats — Excel will render these natively
-        ->setColumnFormat(1, 'integer')        // ID
-        ->setColumnFormat(7, 'date')           // Created Date
-        ->setColumnFormat(8, 'datetime')       // Last Active
-        ->setColumnFormat(9, 'currency_try')   // Salary
-        ->setColumnFormat(10, 'percent')       // Performance score
-        // explicit + auto column widths
-        ->setAutoColumnWidth()
-        ->setColumnWidths([4 => 24, 5 => 16, 6 => 14, 7 => 12, 8 => 18])
-        // freeze header row + auto-filter dropdowns
+        ->setColumnFormat(1, 'integer')
+        ->setColumnFormat(5, 'currency_try')   // ₺
+        ->setColumnFormat(6, 'currency_usd')   // $
+        ->setColumnFormat(7, 'percent')
+        ->setColumnFormat(8, 'date')
+        ->setColumnFormat(9, 'datetime')
+        ->setAutoColumnWidth()                 // format-aware widths now
+        ->setColumnWidths([2 => 22, 4 => 18])  // override Customer + Region wider
         ->freezeFirstRow()
         ->enableAutoFilter();
 
-    // ─── progress callback (v2.1) ──────────────────────────────────
-    $startTime = microtime(true);
-    $writer->onProgress(function (int $rows, int $bytes) use ($startTime) {
-        $elapsed = microtime(true) - $startTime;
-        $rate = $rows / max($elapsed, 0.001);
-        echo sprintf(
-            "  %s rows | %.2f MB streamed | %.0f rows/sec\n",
-            number_format($rows),
-            $bytes / 1024 / 1024,
-            $rate
-        );
-    })->setProgressInterval(10000);
-
-    // ─── sheet 1: Users (50,000 rows) ──────────────────────────────
-    echo "Sheet 1: Users\n";
-
     $writer->startFile([
-        'ID',
-        'Username',
-        'Email',
-        'Full Name',
-        'Department',
-        'Role',
-        'Created Date',
-        'Last Active',
-        'Salary',
-        'Performance',
+        'Order ID',
+        'Customer',
+        'Product Code',
+        'Region',
+        'Price (TRY)',
+        'Price (USD)',
+        'Discount',
+        'Order Date',
+        'Created At',
     ]);
 
-    $departments = ['Engineering', 'Product', 'Sales', 'Marketing', 'Support', 'Operations'];
-    $roles = ['Admin', 'Manager', 'Employee', 'Contractor'];
+    $regions = ['Europe', 'North America', 'Asia-Pacific', 'LATAM', 'MENA'];
+    $products = ['SKU-A001', 'SKU-A002', 'SKU-B100', 'SKU-B101', 'SKU-C500'];
 
     for ($i = 1; $i <= 50_000; $i++) {
         $writer->writeRow([
-            $i,                                                                         // 1: integer
-            "user_{$i}",                                                                // 2: string
-            "user{$i}@company.com",                                                     // 3: string
-            "User Name {$i}",                                                           // 4: string
-            $departments[$i % count($departments)],                                     // 5: string
-            $roles[$i % count($roles)],                                                 // 6: string
-            new DateTime('2026-01-01 +'.($i % 90).' days', new DateTimeZone('UTC')),    // 7: date
-            new DateTime('2026-05-01 -'.($i % 7).' days', new DateTimeZone('UTC')),     // 8: datetime
-            45000 + ($i % 80) * 1000,                                                   // 9: currency
-            ($i % 100) / 100,                                                           // 10: percent
+            $i,
+            "Customer Co. #{$i}",
+            $products[$i % 5],
+            $regions[$i % 5],
+            999.99 + ($i % 1000) * 12.5,             // ₺
+            (999.99 + ($i % 1000) * 12.5) / 33.5,    // USD
+            ($i % 100) / 100,                        // 0.00 - 0.99
+            new DateTime('2026-01-01 +'.($i % 365).' days', new DateTimeZone('UTC')),
+            new DateTime('2026-05-03 -'.($i % 30).' hours', new DateTimeZone('UTC')),
         ]);
     }
 
-    // ─── sheet 2: Summary ──────────────────────────────────────────
-    echo "\nSheet 2: Summary\n";
+    // ════════════════════════════════════════════════════════════════
+    // Sheet 2 — Edge cases (data-quality stress test)
+    // ════════════════════════════════════════════════════════════════
+    echo "[2/5] Sheet 'Edge Cases' — special values\n";
 
     $writer
-        ->setHeaderStyle(['bold' => true, 'fill' => '#9BBB59', 'color' => '#FFFFFF'])
-        ->setColumnFormat(2, 'integer')
-        ->newSheet('Summary', ['Department', 'Headcount']);
+        ->clearColumnFormats()
+        ->setHeaderStyle(['bold' => true, 'fill' => '#C0504D', 'color' => '#FFFFFF'])
+        ->setColumnFormat(1, 'integer')
+        ->setAutoColumnWidth()
+        ->newSheet('Edge Cases', [
+            'Row',
+            'Empty',
+            'Null',
+            'Boolean True',
+            'Boolean False',
+            'Big Int (20 digits)',
+            'Phone (+prefix)',
+            'Leading Zero',
+            'Special XML Chars',
+            'Multi-byte UTF-8',
+            'Whitespace',
+            'Negative',
+        ]);
 
-    foreach ($departments as $dept) {
-        $writer->writeRow([$dept, rand(500, 15000)]);
+    $writer->writeRow([1, '', null, true, false, '12345678901234567890', '+905551234567', '00123', '<tag>&"\'', 'Türkçe → İŞŞL', '   leading', -42]);
+    $writer->writeRow([2, '', null, false, true, '99999999999999999999', '+447911123456', '00007', 'a < b && c > d', '日本語テスト', 'trailing   ', -3.14]);
+    $writer->writeRow([3, null, null, true, true, '1234567890', '+1234567890', '0001', '"quoted"', 'العربية', "\ttab\t", 0]);
+
+    // ════════════════════════════════════════════════════════════════
+    // Sheet 3 — Manual column widths only (no auto)
+    // ════════════════════════════════════════════════════════════════
+    echo "[3/5] Sheet 'Manual Widths'\n";
+
+    $writer
+        ->clearColumnFormats()
+        ->setHeaderStyle(['bold' => true, 'fill' => '#9BBB59', 'color' => '#FFFFFF'])
+        ->setAutoColumnWidth(false)
+        ->setColumnWidths([1 => 6, 2 => 40, 3 => 12, 4 => 30])
+        ->newSheet('Manual Widths', ['#', 'Long Description Column', 'Code', 'Notes']);
+
+    for ($i = 1; $i <= 50; $i++) {
+        $writer->writeRow([
+            $i,
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur '.$i,
+            'CODE-'.str_pad($i, 4, '0', STR_PAD_LEFT),
+            'Note '.$i,
+        ]);
     }
 
-    // ─── finalize ──────────────────────────────────────────────────
+    // ════════════════════════════════════════════════════════════════
+    // Sheet 4 — Number format presets gallery
+    // ════════════════════════════════════════════════════════════════
+    echo "[4/5] Sheet 'Format Gallery'\n";
+
+    $writer
+        ->clearColumnFormats()
+        ->setHeaderStyle(['bold' => true, 'fill' => '#8064A2', 'color' => '#FFFFFF'])
+        ->setColumnFormat(2, 'integer')
+        ->setColumnFormat(3, 'decimal')
+        ->setColumnFormat(4, 'percent')
+        ->setColumnFormat(5, 'currency_try')
+        ->setColumnFormat(6, 'currency_usd')
+        ->setColumnFormat(7, 'currency_eur')
+        ->setColumnFormat(8, 'currency_gbp')
+        ->setColumnFormat(9, 'date')
+        ->setColumnFormat(10, 'datetime')
+        ->setColumnFormat(11, 'time')
+        ->setColumnFormat(12, '0.000000') // raw custom format code
+        ->setAutoColumnWidth()
+        ->newSheet('Format Gallery', [
+            'Label',
+            'integer',
+            'decimal',
+            'percent',
+            'currency_try',
+            'currency_usd',
+            'currency_eur',
+            'currency_gbp',
+            'date',
+            'datetime',
+            'time',
+            'custom 0.000000',
+        ]);
+
+    $samples = [
+        ['Small', 1, 1.5, 0.01, 9.99, 9.99, 9.99, 9.99],
+        ['Medium', 12345, 1234.56, 0.5, 99999.99, 99999.99, 99999.99, 99999.99],
+        ['Large', 1234567890, 9876543.21, 0.999, 1234567.89, 1234567.89, 1234567.89, 1234567.89],
+        ['Negative', -42, -3.14, -0.05, -250, -250, -250, -250],
+        ['Zero', 0, 0, 0, 0, 0, 0, 0],
+    ];
+    $time = new DateTime('2026-05-03 14:23:45', new DateTimeZone('UTC'));
+    foreach ($samples as $row) {
+        $writer->writeRow(array_merge($row, [$time, $time, $time, 0.123456789]));
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Sheet 5 — Frozen pane + many columns wide layout
+    // ════════════════════════════════════════════════════════════════
+    echo "[5/5] Sheet 'Wide Layout'\n";
+
+    $writer
+        ->clearColumnFormats()
+        ->setHeaderStyle(['bold' => true, 'fill' => '#1F497D', 'color' => '#FFFFFF'])
+        ->freezeRowsAndColumns(rows: 1, columns: 2)
+        ->enableAutoFilter()
+        ->setAutoColumnWidth()
+        ->setColumnFormat(1, 'integer')
+        ->setColumnFormat(3, 'currency_try')
+        ->setColumnFormat(4, 'currency_try')
+        ->setColumnFormat(5, 'currency_try')
+        ->setColumnFormat(6, 'currency_try')
+        ->setColumnFormat(7, 'currency_try')
+        ->setColumnFormat(8, 'percent')
+        ->setColumnFormat(9, 'datetime')
+        ->newSheet('Wide Layout', [
+            'ID', 'Name',
+            'Q1 Sales', 'Q2 Sales', 'Q3 Sales', 'Q4 Sales',
+            'Total', 'Growth %',
+            'Last Update',
+        ]);
+
+    for ($i = 1; $i <= 200; $i++) {
+        $q1 = 50000 + ($i * 137) % 80000;
+        $q2 = 60000 + ($i * 211) % 90000;
+        $q3 = 55000 + ($i * 173) % 85000;
+        $q4 = 70000 + ($i * 191) % 100000;
+        $total = $q1 + $q2 + $q3 + $q4;
+        $writer->writeRow([
+            $i,
+            "Account-".str_pad($i, 4, '0', STR_PAD_LEFT),
+            $q1, $q2, $q3, $q4,
+            $total,
+            ($i % 25 - 12) / 100,
+            new DateTime('2026-05-01 +'.($i % 48).' hours', new DateTimeZone('UTC')),
+        ]);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Finalize
+    // ════════════════════════════════════════════════════════════════
     $stats = $writer->finishFile();
     $totalTime = microtime(true) - $startTime;
 
@@ -155,7 +280,7 @@ function exportToS3(array $awsConfig, string $bucketName): void
     echo "File:       s3://{$bucketName}/{$key}\n";
     echo "Sheets:     {$stats['sheets']}\n";
     foreach ($stats['sheet_details'] as $sheet) {
-        echo sprintf("  • %-12s %s rows\n", $sheet['name'], number_format($sheet['rows']));
+        echo sprintf("  • %-16s %s rows\n", $sheet['name'], number_format($sheet['rows']));
     }
     echo 'Total rows: '.number_format($stats['rows'])."\n";
     echo 'File size:  '.number_format($stats['bytes'])." bytes\n";
@@ -163,7 +288,6 @@ function exportToS3(array $awsConfig, string $bucketName): void
     echo 'Speed:      '.number_format($stats['rows'] / $totalTime, 0)." rows/sec\n";
     echo 'Peak mem:   '.number_format(memory_get_peak_usage(true) / 1024 / 1024, 2)." MB\n";
 
-    // Presigned URL for quick browser download
     try {
         $cmd = $s3->getCommand('GetObject', ['Bucket' => $bucketName, 'Key' => $key]);
         $url = (string) $s3->createPresignedRequest($cmd, '+1 hour')->getUri();

--- a/examples/s3-streaming.php
+++ b/examples/s3-streaming.php
@@ -1,21 +1,30 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
-use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
-use Kolay\XlsxStream\Sinks\S3MultipartSink;
 use Aws\S3\S3Client;
+use Kolay\XlsxStream\Sinks\S3MultipartSink;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
 
 /**
- * Example: Direct S3 Streaming with Zero Disk I/O
- * 
- * This example demonstrates how to stream XLSX files directly to S3
- * without using any local disk space.
+ * Example: Direct S3 Streaming with Zero Disk I/O — showcases v2.2 styling.
+ *
+ * Generates a multi-sheet workbook with header styling, column formats,
+ * frozen first row, auto-filter, auto column widths, and progress reporting,
+ * then streams it straight to S3 using multipart upload (no temp files).
+ *
+ * Run with AWS env vars set, then download the file from S3 to inspect:
+ *   AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_BUCKET=... \
+ *     AWS_DEFAULT_REGION=us-east-2 php examples/s3-streaming.php
  */
 
-// Configure your AWS credentials
+// Bootstrap config from env (or .env if vlucas/phpdotenv is in the autoloader)
+if (file_exists(__DIR__.'/../.env') && class_exists(\Dotenv\Dotenv::class)) {
+    \Dotenv\Dotenv::createUnsafeImmutable(__DIR__.'/..')->safeLoad();
+}
+
 $awsConfig = [
-    'region' => 'us-east-1', // Change to your region
+    'region' => getenv('AWS_DEFAULT_REGION') ?: 'us-east-1',
     'version' => 'latest',
     'credentials' => [
         'key' => getenv('AWS_ACCESS_KEY_ID'),
@@ -25,161 +34,149 @@ $awsConfig = [
 
 $bucketName = getenv('AWS_BUCKET') ?: 'your-bucket-name';
 
-function exportToS3()
+if (! getenv('AWS_ACCESS_KEY_ID') || ! getenv('AWS_SECRET_ACCESS_KEY') || $bucketName === 'your-bucket-name') {
+    echo "ERROR: AWS credentials not found.\n";
+    echo "Set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET, AWS_DEFAULT_REGION.\n";
+    exit(1);
+}
+
+function exportToS3(array $awsConfig, string $bucketName): void
 {
-    global $awsConfig, $bucketName;
-    
-    echo "Starting S3 streaming export...\n";
-    echo "Bucket: $bucketName\n\n";
-    
-    // Create S3 client
-    $s3Client = new S3Client($awsConfig);
-    
-    // Create S3 sink with 32MB parts for optimal performance
-    $filename = 'exports/users-' . date('Y-m-d-H-i-s') . '.xlsx';
+    echo "Streaming styled multi-sheet workbook to S3...\n";
+    echo "Bucket: {$bucketName}\n\n";
+
+    $s3 = new S3Client($awsConfig);
+    $key = 'examples/styled-'.date('Ymd-His').'.xlsx';
+
     $sink = new S3MultipartSink(
-        $s3Client,
+        $s3,
         $bucketName,
-        $filename,
-        32 * 1024 * 1024, // 32MB parts
+        $key,
+        32 * 1024 * 1024, // 32 MB parts
         [
             'ACL' => 'private',
-            'ContentType' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'ContentDisposition' => 'attachment; filename="users-export.xlsx"',
             'Metadata' => [
                 'generated-by' => 'kolay-xlsx-stream',
                 'generated-at' => date('c'),
-            ]
+            ],
         ]
     );
-    
-    // Create writer
+
     $writer = new SinkableXlsxWriter($sink);
-    
-    // Optimize for S3 streaming
-    $writer->setCompressionLevel(1)        // Fast compression
-           ->setBufferFlushInterval(10000); // 10K row buffer
-    
-    // Start file with headers
+
+    // ─── v2.2 styling ──────────────────────────────────────────────
+    $writer
+        ->setCompressionLevel(1)
+        ->setBufferFlushInterval(10000)
+        // header: bold white text on dark blue
+        ->setHeaderStyle([
+            'bold' => true,
+            'fill' => '#4F81BD',
+            'color' => '#FFFFFF',
+        ])
+        // column number formats — Excel will render these natively
+        ->setColumnFormat(1, 'integer')        // ID
+        ->setColumnFormat(7, 'date')           // Created Date
+        ->setColumnFormat(8, 'datetime')       // Last Active
+        ->setColumnFormat(9, 'currency_try')   // Salary
+        ->setColumnFormat(10, 'percent')       // Performance score
+        // explicit + auto column widths
+        ->setAutoColumnWidth()
+        ->setColumnWidths([4 => 24, 5 => 16, 6 => 14, 7 => 12, 8 => 18])
+        // freeze header row + auto-filter dropdowns
+        ->freezeFirstRow()
+        ->enableAutoFilter();
+
+    // ─── progress callback (v2.1) ──────────────────────────────────
+    $startTime = microtime(true);
+    $writer->onProgress(function (int $rows, int $bytes) use ($startTime) {
+        $elapsed = microtime(true) - $startTime;
+        $rate = $rows / max($elapsed, 0.001);
+        echo sprintf(
+            "  %s rows | %.2f MB streamed | %.0f rows/sec\n",
+            number_format($rows),
+            $bytes / 1024 / 1024,
+            $rate
+        );
+    })->setProgressInterval(10000);
+
+    // ─── sheet 1: Users (50,000 rows) ──────────────────────────────
+    echo "Sheet 1: Users\n";
+
     $writer->startFile([
-        'User ID',
+        'ID',
         'Username',
         'Email',
         'Full Name',
         'Department',
         'Role',
-        'Status',
         'Created Date',
-        'Last Active'
+        'Last Active',
+        'Salary',
+        'Performance',
     ]);
-    
-    // Simulate database query with chunking
-    $totalUsers = 100000;
-    $chunkSize = 1000;
+
     $departments = ['Engineering', 'Product', 'Sales', 'Marketing', 'Support', 'Operations'];
     $roles = ['Admin', 'Manager', 'Employee', 'Contractor'];
-    $statuses = ['Active', 'Inactive', 'Pending'];
-    
-    $startTime = microtime(true);
-    
-    for ($offset = 0; $offset < $totalUsers; $offset += $chunkSize) {
-        // Simulate chunk of users from database
-        $users = [];
-        for ($i = 1; $i <= $chunkSize && ($offset + $i) <= $totalUsers; $i++) {
-            $userId = $offset + $i;
-            $users[] = [
-                'id' => $userId,
-                'username' => "user_$userId",
-                'email' => "user$userId@company.com",
-                'full_name' => "User Name $userId",
-                'department' => $departments[array_rand($departments)],
-                'role' => $roles[array_rand($roles)],
-                'status' => $statuses[array_rand($statuses)],
-                'created_date' => date('Y-m-d', time() - rand(0, 365 * 24 * 60 * 60)),
-                'last_active' => date('Y-m-d H:i:s', time() - rand(0, 7 * 24 * 60 * 60))
-            ];
-        }
-        
-        // Write users to XLSX
-        foreach ($users as $user) {
-            $writer->writeRow([
-                $user['id'],
-                $user['username'],
-                $user['email'],
-                $user['full_name'],
-                $user['department'],
-                $user['role'],
-                $user['status'],
-                $user['created_date'],
-                $user['last_active']
-            ]);
-        }
-        
-        // Progress update
-        if (($offset + $chunkSize) % 10000 === 0) {
-            $progress = min($offset + $chunkSize, $totalUsers);
-            $elapsed = microtime(true) - $startTime;
-            $rate = $progress / $elapsed;
-            echo sprintf(
-                "Progress: %s / %s rows (%.1f%%) - %.0f rows/sec\n",
-                number_format($progress),
-                number_format($totalUsers),
-                ($progress / $totalUsers) * 100,
-                $rate
-            );
-        }
-    }
-    
-    // Finish file and upload
-    echo "\nFinalizing S3 upload...\n";
-    $stats = $writer->finishFile();
-    
-    $totalTime = microtime(true) - $startTime;
-    
-    echo "\n=== S3 Export Completed ===\n";
-    echo "File: s3://$bucketName/$filename\n";
-    echo "Total rows: " . number_format($stats['rows']) . "\n";
-    echo "Total sheets: {$stats['sheets']}\n";
-    echo "File size: " . number_format($stats['bytes']) . " bytes\n";
-    echo "Time taken: " . round($totalTime, 2) . " seconds\n";
-    echo "Average speed: " . number_format($stats['rows'] / $totalTime, 0) . " rows/sec\n";
-    echo "Memory peak: " . number_format(memory_get_peak_usage(true) / 1024 / 1024, 2) . " MB\n";
-    
-    // Generate presigned URL for download (optional)
-    try {
-        $cmd = $s3Client->getCommand('GetObject', [
-            'Bucket' => $bucketName,
-            'Key' => $filename
+
+    for ($i = 1; $i <= 50_000; $i++) {
+        $writer->writeRow([
+            $i,                                                                         // 1: integer
+            "user_{$i}",                                                                // 2: string
+            "user{$i}@company.com",                                                     // 3: string
+            "User Name {$i}",                                                           // 4: string
+            $departments[$i % count($departments)],                                     // 5: string
+            $roles[$i % count($roles)],                                                 // 6: string
+            new DateTime('2026-01-01 +'.($i % 90).' days', new DateTimeZone('UTC')),    // 7: date
+            new DateTime('2026-05-01 -'.($i % 7).' days', new DateTimeZone('UTC')),     // 8: datetime
+            45000 + ($i % 80) * 1000,                                                   // 9: currency
+            ($i % 100) / 100,                                                           // 10: percent
         ]);
-        $request = $s3Client->createPresignedRequest($cmd, '+1 hour');
-        $presignedUrl = (string) $request->getUri();
-        
-        echo "\nDownload URL (valid for 1 hour):\n";
-        echo $presignedUrl . "\n";
-    } catch (Exception $e) {
-        echo "\nCould not generate presigned URL: " . $e->getMessage() . "\n";
+    }
+
+    // ─── sheet 2: Summary ──────────────────────────────────────────
+    echo "\nSheet 2: Summary\n";
+
+    $writer
+        ->setHeaderStyle(['bold' => true, 'fill' => '#9BBB59', 'color' => '#FFFFFF'])
+        ->setColumnFormat(2, 'integer')
+        ->newSheet('Summary', ['Department', 'Headcount']);
+
+    foreach ($departments as $dept) {
+        $writer->writeRow([$dept, rand(500, 15000)]);
+    }
+
+    // ─── finalize ──────────────────────────────────────────────────
+    $stats = $writer->finishFile();
+    $totalTime = microtime(true) - $startTime;
+
+    echo "\n=== S3 Export Completed ===\n";
+    echo "File:       s3://{$bucketName}/{$key}\n";
+    echo "Sheets:     {$stats['sheets']}\n";
+    foreach ($stats['sheet_details'] as $sheet) {
+        echo sprintf("  • %-12s %s rows\n", $sheet['name'], number_format($sheet['rows']));
+    }
+    echo 'Total rows: '.number_format($stats['rows'])."\n";
+    echo 'File size:  '.number_format($stats['bytes'])." bytes\n";
+    echo 'Time:       '.round($totalTime, 2)." s\n";
+    echo 'Speed:      '.number_format($stats['rows'] / $totalTime, 0)." rows/sec\n";
+    echo 'Peak mem:   '.number_format(memory_get_peak_usage(true) / 1024 / 1024, 2)." MB\n";
+
+    // Presigned URL for quick browser download
+    try {
+        $cmd = $s3->getCommand('GetObject', ['Bucket' => $bucketName, 'Key' => $key]);
+        $url = (string) $s3->createPresignedRequest($cmd, '+1 hour')->getUri();
+        echo "\nDownload (valid 1 hour):\n{$url}\n";
+    } catch (\Throwable $e) {
+        echo "\nCould not generate presigned URL: ".$e->getMessage()."\n";
     }
 }
 
-// Check AWS credentials
-if (!getenv('AWS_ACCESS_KEY_ID') || !getenv('AWS_SECRET_ACCESS_KEY')) {
-    echo "ERROR: AWS credentials not found!\n";
-    echo "Please set the following environment variables:\n";
-    echo "  AWS_ACCESS_KEY_ID\n";
-    echo "  AWS_SECRET_ACCESS_KEY\n";
-    echo "  AWS_BUCKET (optional)\n\n";
-    echo "Example:\n";
-    echo "  export AWS_ACCESS_KEY_ID=your_key_here\n";
-    echo "  export AWS_SECRET_ACCESS_KEY=your_secret_here\n";
-    echo "  export AWS_BUCKET=your-bucket-name\n";
-    echo "  php " . __FILE__ . "\n";
-    exit(1);
-}
-
-// Run the export
 try {
-    exportToS3();
-} catch (Exception $e) {
-    echo "\nERROR: " . $e->getMessage() . "\n";
-    echo "Stack trace:\n" . $e->getTraceAsString() . "\n";
+    exportToS3($awsConfig, $bucketName);
+} catch (\Throwable $e) {
+    echo "\nERROR: ".$e->getMessage()."\n";
+    echo $e->getTraceAsString()."\n";
     exit(1);
 }

--- a/src/Styles/StyleRegistry.php
+++ b/src/Styles/StyleRegistry.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Kolay\XlsxStream\Styles;
+
+/**
+ * Builds the dynamic portion of xl/styles.xml.
+ *
+ * The writer registers logical styles (header, column formats) here and gets
+ * back stable cellXfs indexes (style ids) that it can stamp onto cells via
+ * `s="N"`. Styles that aren't used aren't emitted, so the styles.xml stays
+ * tight regardless of how many presets are exposed.
+ *
+ * Indexes are append-only and stable for the lifetime of a writer — that lets
+ * the row builder cache style ids per column without invalidation.
+ */
+class StyleRegistry
+{
+    /** Excel built-in numFmtIds (no <numFmt> entry needed). */
+    public const BUILTIN_NUMFMT_GENERAL = 0;
+    public const BUILTIN_NUMFMT_INT = 1;        // 0
+    public const BUILTIN_NUMFMT_TWO_DECIMAL = 2; // 0.00
+    public const BUILTIN_NUMFMT_DATE = 14;      // m/d/yyyy
+    public const BUILTIN_NUMFMT_DATETIME = 22;  // m/d/yyyy h:mm
+
+    /** Custom numFmtIds start at 164 per OOXML spec. */
+    private const CUSTOM_NUMFMT_START = 164;
+
+    /**
+     * Named format presets. Values are Excel format codes.
+     *
+     * Tip: locale-specific currency presets (`currency_try` etc.) use the
+     * literal symbol so the file is self-contained — no need for the user's
+     * Excel locale to be set.
+     */
+    public const PRESETS = [
+        'date' => 'yyyy-mm-dd',
+        'datetime' => 'yyyy-mm-dd hh:mm:ss',
+        'datetime_iso' => 'yyyy-mm-dd"T"hh:mm:ss',
+        'time' => 'hh:mm:ss',
+        'integer' => '#,##0',
+        'decimal' => '#,##0.00',
+        'percent' => '0.00%',
+        'currency_try' => '#,##0.00\\ ₺',
+        'currency_usd' => '$#,##0.00',
+        'currency_eur' => '€#,##0.00',
+        'currency_gbp' => '£#,##0.00',
+    ];
+
+    /** @var array<string, int> formatCode => numFmtId */
+    private array $customNumFmts = [];
+
+    /** @var array<int, array{numFmtId:int, fontId:int, fillId:int, applyNumberFormat:int, applyFont:int, applyFill:int}> */
+    private array $cellXfs = [
+        // index 0 = default, index 1 = preserved historical datetime style
+        ['numFmtId' => 0, 'fontId' => 0, 'fillId' => 0, 'applyNumberFormat' => 0, 'applyFont' => 0, 'applyFill' => 0],
+        ['numFmtId' => 164, 'fontId' => 0, 'fillId' => 0, 'applyNumberFormat' => 1, 'applyFont' => 0, 'applyFill' => 0],
+    ];
+
+    /** @var array<int, array{bold:bool, color:?string, size:int, name:string}> */
+    private array $fonts = [
+        ['bold' => false, 'color' => null, 'size' => 11, 'name' => 'Calibri'],
+    ];
+
+    /** @var array<int, ?string> indexed by fillId; null = no fill (use built-in 0/1). */
+    private array $fills = [
+        null, // built-in: <patternFill patternType="none"/>
+        null, // built-in: <patternFill patternType="gray125"/>
+    ];
+
+    public function __construct()
+    {
+        // Reserve numFmtId 164 for the legacy datetime format used at cellXfs[1].
+        $this->customNumFmts['yyyy-mm-dd hh:mm:ss'] = 164;
+    }
+
+    /**
+     * Register a number format and return its cellXfs index (style id).
+     *
+     * Accepts a preset name (e.g. "date", "currency_try") or a raw Excel
+     * format code (e.g. "0.000"). Same code → same style id (idempotent).
+     */
+    public function registerColumnFormat(string $presetOrCode): int
+    {
+        $code = self::PRESETS[$presetOrCode] ?? $presetOrCode;
+
+        $numFmtId = $this->resolveNumFmtId($code);
+
+        return $this->resolveCellXf([
+            'numFmtId' => $numFmtId,
+            'fontId' => 0,
+            'fillId' => 0,
+            'applyNumberFormat' => 1,
+            'applyFont' => 0,
+            'applyFill' => 0,
+        ]);
+    }
+
+    /**
+     * Register a header style and return its cellXfs index.
+     *
+     * Options: bold (bool), color (#RRGGBB), fill (#RRGGBB), size (int).
+     */
+    public function registerHeaderStyle(array $options): int
+    {
+        $fontId = $this->resolveFont([
+            'bold' => (bool) ($options['bold'] ?? false),
+            'color' => $options['color'] ?? null,
+            'size' => (int) ($options['size'] ?? 11),
+            'name' => 'Calibri',
+        ]);
+
+        $fillId = isset($options['fill']) ? $this->resolveFill($options['fill']) : 0;
+
+        return $this->resolveCellXf([
+            'numFmtId' => 0,
+            'fontId' => $fontId,
+            'fillId' => $fillId,
+            'applyNumberFormat' => 0,
+            'applyFont' => $fontId > 0 ? 1 : 0,
+            'applyFill' => $fillId > 0 ? 1 : 0,
+        ]);
+    }
+
+    /**
+     * Render xl/styles.xml.
+     */
+    public function toXml(): string
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+        $xml .= '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">';
+
+        // <numFmts>
+        if (! empty($this->customNumFmts)) {
+            $xml .= '<numFmts count="'.count($this->customNumFmts).'">';
+            foreach ($this->customNumFmts as $code => $id) {
+                $xml .= '<numFmt numFmtId="'.$id.'" formatCode="'.htmlspecialchars($code, ENT_QUOTES | ENT_XML1).'"/>';
+            }
+            $xml .= '</numFmts>';
+        }
+
+        // <fonts>
+        $xml .= '<fonts count="'.count($this->fonts).'">';
+        foreach ($this->fonts as $font) {
+            $xml .= '<font>';
+            $xml .= '<sz val="'.$font['size'].'"/>';
+            if ($font['bold']) {
+                $xml .= '<b/>';
+            }
+            if ($font['color'] !== null) {
+                $xml .= '<color rgb="FF'.ltrim($font['color'], '#').'"/>';
+            }
+            $xml .= '<name val="'.$font['name'].'"/>';
+            $xml .= '</font>';
+        }
+        $xml .= '</fonts>';
+
+        // <fills> — first 2 are required built-ins
+        $xml .= '<fills count="'.count($this->fills).'">';
+        $xml .= '<fill><patternFill patternType="none"/></fill>';
+        $xml .= '<fill><patternFill patternType="gray125"/></fill>';
+        for ($i = 2; $i < count($this->fills); $i++) {
+            $color = ltrim($this->fills[$i] ?? '', '#');
+            $xml .= '<fill><patternFill patternType="solid"><fgColor rgb="FF'.$color.'"/></patternFill></fill>';
+        }
+        $xml .= '</fills>';
+
+        $xml .= '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>';
+
+        // <cellXfs>
+        $xml .= '<cellXfs count="'.count($this->cellXfs).'">';
+        foreach ($this->cellXfs as $xf) {
+            $xml .= '<xf';
+            $xml .= ' numFmtId="'.$xf['numFmtId'].'"';
+            $xml .= ' fontId="'.$xf['fontId'].'"';
+            $xml .= ' fillId="'.$xf['fillId'].'"';
+            $xml .= ' borderId="0"';
+            $xml .= ' xfId="0"';
+            if ($xf['applyNumberFormat']) {
+                $xml .= ' applyNumberFormat="1"';
+            }
+            if ($xf['applyFont']) {
+                $xml .= ' applyFont="1"';
+            }
+            if ($xf['applyFill']) {
+                $xml .= ' applyFill="1"';
+            }
+            $xml .= '/>';
+        }
+        $xml .= '</cellXfs>';
+
+        $xml .= '</styleSheet>';
+
+        return $xml;
+    }
+
+    private function resolveNumFmtId(string $code): int
+    {
+        if (isset($this->customNumFmts[$code])) {
+            return $this->customNumFmts[$code];
+        }
+
+        $id = self::CUSTOM_NUMFMT_START + count($this->customNumFmts);
+        $this->customNumFmts[$code] = $id;
+
+        return $id;
+    }
+
+    private function resolveCellXf(array $xf): int
+    {
+        foreach ($this->cellXfs as $i => $existing) {
+            if ($existing == $xf) {
+                return $i;
+            }
+        }
+        $this->cellXfs[] = $xf;
+
+        return count($this->cellXfs) - 1;
+    }
+
+    private function resolveFont(array $font): int
+    {
+        foreach ($this->fonts as $i => $existing) {
+            if ($existing == $font) {
+                return $i;
+            }
+        }
+        $this->fonts[] = $font;
+
+        return count($this->fonts) - 1;
+    }
+
+    private function resolveFill(string $color): int
+    {
+        $color = ltrim($color, '#');
+        foreach ($this->fills as $i => $existing) {
+            if ($i < 2) {
+                continue; // skip built-ins
+            }
+            if (ltrim((string) $existing, '#') === $color) {
+                return $i;
+            }
+        }
+        $this->fills[] = $color;
+
+        return count($this->fills) - 1;
+    }
+}

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -83,6 +83,9 @@ abstract class BaseXlsxWriter
     /** @var array<int, int> 1-based column index => cellXfs style id */
     protected array $columnStyleIds = [];
 
+    /** @var array<int, string> 1-based column index => format preset name (used for auto-width sizing) */
+    protected array $columnFormatNames = [];
+
     // Sheet view options (v2.2+)
     protected int $freezeRows = 0;
     protected int $freezeColumns = 0;
@@ -214,12 +217,14 @@ abstract class BaseXlsxWriter
      */
     public function freezeRowsAndColumns(int $rows = 1, int $columns = 0): self
     {
-        if ($this->started) {
-            throw new XlsxStreamException('freezeRowsAndColumns() must be called before startFile().');
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
         }
         if ($rows < 0 || $columns < 0) {
             throw new XlsxStreamException('Freeze rows/columns must be >= 0.');
         }
+        // Settable any time before close — applies to the next sheet started
+        // via writeRow() or newSheet().
         $this->freezeRows = $rows;
         $this->freezeColumns = $columns;
 
@@ -238,8 +243,8 @@ abstract class BaseXlsxWriter
      */
     public function setColumnWidths(array $widths): self
     {
-        if ($this->started) {
-            throw new XlsxStreamException('setColumnWidths() must be called before startFile().');
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
         }
         foreach ($widths as $col => $width) {
             if ($col < 1) {
@@ -266,8 +271,8 @@ abstract class BaseXlsxWriter
      */
     public function setAutoColumnWidth(bool $enabled = true): self
     {
-        if ($this->started) {
-            throw new XlsxStreamException('setAutoColumnWidth() must be called before startFile().');
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
         }
         $this->autoColumnWidth = $enabled;
 
@@ -280,12 +285,12 @@ abstract class BaseXlsxWriter
      * The filter range is computed automatically from the sheet's columns
      * and final row count when the sheet is closed.
      */
-    public function enableAutoFilter(): self
+    public function enableAutoFilter(bool $enabled = true): self
     {
-        if ($this->started) {
-            throw new XlsxStreamException('enableAutoFilter() must be called before startFile().');
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
         }
-        $this->autoFilterEnabled = true;
+        $this->autoFilterEnabled = $enabled;
 
         return $this;
     }
@@ -312,6 +317,29 @@ abstract class BaseXlsxWriter
             throw new XlsxStreamException("Column index must be >= 1, got {$column}.");
         }
         $this->columnStyleIds[$column] = $this->styles->registerColumnFormat($presetOrCode);
+        // Stored separately so the auto-width heuristic can pick a sensible
+        // minimum based on the format (e.g. currency cells need ~14 chars
+        // even when the header is shorter).
+        $this->columnFormatNames[$column] = $presetOrCode;
+
+        return $this;
+    }
+
+    /**
+     * Clear all column-level formats and widths.
+     *
+     * Useful between newSheet() calls when the next sheet has a different
+     * column layout — without this, formats set on the previous sheet leak
+     * into the next sheet's numeric cells and auto-width calculations.
+     */
+    public function clearColumnFormats(): self
+    {
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
+        }
+        $this->columnStyleIds = [];
+        $this->columnFormatNames = [];
+        $this->columnWidths = [];
 
         return $this;
     }
@@ -622,7 +650,10 @@ abstract class BaseXlsxWriter
      *
      * Resolution order (per column):
      *   1. Explicit width from setColumnWidths()
-     *   2. Heuristic from header text length when setAutoColumnWidth(true)
+     *   2. setAutoColumnWidth() heuristic: max(format_min, header_len + 2, 8)
+     *      where format_min reflects the rendered width of values formatted
+     *      as date / datetime / currency / percent / decimal — fixes the
+     *      "Salary header is 6 chars but ₺50,000.00 needs ~14 chars" case
      *   3. Excel default (no <col> entry)
      */
     protected function buildColsXml(): string
@@ -638,7 +669,8 @@ abstract class BaseXlsxWriter
             }
             if ($this->autoColumnWidth && isset($this->columns[$col - 1])) {
                 $headerLen = mb_strlen((string) $this->columns[$col - 1], 'UTF-8');
-                $resolved[$col] = (float) max(8, $headerLen + 2);
+                $formatMin = $this->minWidthForFormat($this->columnFormatNames[$col] ?? null);
+                $resolved[$col] = (float) max(8, $headerLen + 2, $formatMin);
             }
         }
 
@@ -653,6 +685,27 @@ abstract class BaseXlsxWriter
         $xml .= '</cols>';
 
         return $xml;
+    }
+
+    /**
+     * Minimum sensible column width (in chars) for a given format preset.
+     * Returns 0 for unknown / unformatted columns so the header heuristic wins.
+     */
+    protected function minWidthForFormat(?string $name): int
+    {
+        return match ($name) {
+            'date' => 12,                    // 2026-01-15
+            'datetime', 'datetime_iso' => 20, // 2026-01-15 10:30:00
+            'time' => 10,                    // 10:30:00
+            'currency_try',
+            'currency_usd',
+            'currency_eur',
+            'currency_gbp' => 14,            // ₺99,999.99
+            'percent' => 10,                 // 100.00%
+            'decimal' => 12,                 // 99,999.99
+            'integer' => 10,                 // 99,999,999
+            default => 0,
+        };
     }
 
     /**

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -3,6 +3,7 @@
 namespace Kolay\XlsxStream\Writers;
 
 use Kolay\XlsxStream\Exceptions\XlsxStreamException;
+use Kolay\XlsxStream\Styles\StyleRegistry;
 
 /**
  * Base XLSX Writer - Core streaming functionality
@@ -75,6 +76,18 @@ abstract class BaseXlsxWriter
     protected ?\Closure $progressCallback = null;
     protected int $progressInterval = 10000;
 
+    // Styling (v2.2+)
+    protected StyleRegistry $styles;
+    protected ?int $headerStyleId = null;
+
+    /** @var array<int, int> 1-based column index => cellXfs style id */
+    protected array $columnStyleIds = [];
+
+    public function __construct()
+    {
+        $this->styles = new StyleRegistry();
+    }
+
     /**
      * Write data to destination (must be implemented by child classes)
      */
@@ -139,6 +152,56 @@ abstract class BaseXlsxWriter
             throw XlsxStreamException::invalidBufferSize($rows);
         }
         $this->progressInterval = $rows;
+
+        return $this;
+    }
+
+    /**
+     * Style the header row (the first row written by startFile).
+     *
+     * Options:
+     *  - bold (bool)
+     *  - color (#RRGGBB) — text color
+     *  - fill (#RRGGBB)  — background color
+     *  - size (int)      — font size, default 11
+     *
+     * Example:
+     *
+     *   $writer->setHeaderStyle([
+     *       'bold' => true,
+     *       'fill' => '#4F81BD',
+     *       'color' => '#FFFFFF',
+     *   ]);
+     */
+    public function setHeaderStyle(array $options): self
+    {
+        if ($this->started) {
+            throw new XlsxStreamException('setHeaderStyle() must be called before startFile().');
+        }
+        $this->headerStyleId = $this->styles->registerHeaderStyle($options);
+
+        return $this;
+    }
+
+    /**
+     * Apply a number format to a column (1-based).
+     *
+     * Accepts a preset name (see StyleRegistry::PRESETS) or a raw Excel
+     * format code. Same code reuses the same style id under the hood.
+     *
+     *   $writer->setColumnFormat(2, 'date');           // YYYY-MM-DD
+     *   $writer->setColumnFormat(3, 'currency_try');   // #,##0.00 ₺
+     *   $writer->setColumnFormat(4, '0.000');          // custom code
+     *
+     * Numeric values in that column are wrapped with the chosen format.
+     * String values pass through unchanged.
+     */
+    public function setColumnFormat(int $column, string $presetOrCode): self
+    {
+        if ($column < 1) {
+            throw new XlsxStreamException("Column index must be >= 1, got {$column}.");
+        }
+        $this->columnStyleIds[$column] = $this->styles->registerColumnFormat($presetOrCode);
 
         return $this;
     }
@@ -326,11 +389,12 @@ abstract class BaseXlsxWriter
         $sheetHeader .= '<sheetData>';
 
         if (!empty($this->columns)) {
+            $headerStyleAttr = $this->headerStyleId !== null ? ' s="'.$this->headerStyleId.'"' : '';
             $headerRow = '<row r="1">';
             foreach ($this->columns as $i => $header) {
                 $cellRef = $this->getColumnLetter($i + 1) . '1';
                 $escaped = $this->fastXmlEscape($header);
-                $headerRow .= '<c r="' . $cellRef . '" t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+                $headerRow .= '<c r="' . $cellRef . '"' . $headerStyleAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
             }
             $headerRow .= '</row>';
             $sheetHeader .= $headerRow;
@@ -406,9 +470,11 @@ abstract class BaseXlsxWriter
     {
         $cells = [];
         $colIndex = 1;
+        $hasColumnStyles = ! empty($this->columnStyleIds);
 
         foreach ($data as $value) {
             $cellRef = $this->getColumnLetter($colIndex) . $rowIndex;
+            $colStyleId = $hasColumnStyles ? ($this->columnStyleIds[$colIndex] ?? null) : null;
             $colIndex++;
 
             // Null / empty string -> empty cell
@@ -424,15 +490,18 @@ abstract class BaseXlsxWriter
             }
 
             // DateTimeInterface -> Excel serial date with datetime style
+            // (column-specific format wins if set, else fallback to legacy STYLE_DATETIME)
             if ($value instanceof \DateTimeInterface) {
                 $serial = ($value->getTimestamp() - self::EXCEL_EPOCH_TIMESTAMP) / 86400;
-                $cells[] = '<c r="' . $cellRef . '" s="' . self::STYLE_DATETIME . '" t="n"><v>' . $serial . '</v></c>';
+                $styleId = $colStyleId ?? self::STYLE_DATETIME;
+                $cells[] = '<c r="' . $cellRef . '" s="' . $styleId . '" t="n"><v>' . $serial . '</v></c>';
                 continue;
             }
 
             // Numeric values
             if (is_int($value) || is_float($value)) {
-                $cells[] = '<c r="' . $cellRef . '" t="n"><v>' . $value . '</v></c>';
+                $styleAttr = $colStyleId !== null ? ' s="' . $colStyleId . '"' : '';
+                $cells[] = '<c r="' . $cellRef . '"' . $styleAttr . ' t="n"><v>' . $value . '</v></c>';
                 continue;
             }
 
@@ -442,7 +511,8 @@ abstract class BaseXlsxWriter
                     $escaped = $this->fastXmlEscape($value);
                     $cells[] = '<c r="' . $cellRef . '" t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
                 } else {
-                    $cells[] = '<c r="' . $cellRef . '" t="n"><v>' . (0 + $value) . '</v></c>';
+                    $styleAttr = $colStyleId !== null ? ' s="' . $colStyleId . '"' : '';
+                    $cells[] = '<c r="' . $cellRef . '"' . $styleAttr . ' t="n"><v>' . (0 + $value) . '</v></c>';
                 }
                 continue;
             }
@@ -721,27 +791,6 @@ abstract class BaseXlsxWriter
 
     protected function getStylesXml(): string
     {
-        // Custom numFmt 164 = ISO datetime; 14 (built-in) = m/d/yy date.
-        // cellXfs index 0 = default, index 1 = STYLE_DATETIME (numFmtId 164).
-        return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-    <numFmts count="1">
-        <numFmt numFmtId="164" formatCode="yyyy-mm-dd hh:mm:ss"/>
-    </numFmts>
-    <fonts count="1">
-        <font><sz val="11"/><name val="Calibri"/></font>
-    </fonts>
-    <fills count="2">
-        <fill><patternFill patternType="none"/></fill>
-        <fill><patternFill patternType="gray125"/></fill>
-    </fills>
-    <borders count="1">
-        <border><left/><right/><top/><bottom/><diagonal/></border>
-    </borders>
-    <cellXfs count="2">
-        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
-        <xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>
-    </cellXfs>
-</styleSheet>';
+        return $this->styles->toXml();
     }
 }

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -187,9 +187,11 @@ abstract class BaseXlsxWriter
      */
     public function setHeaderStyle(array $options): self
     {
-        if ($this->started) {
-            throw new XlsxStreamException('setHeaderStyle() must be called before startFile().');
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
         }
+        // Allowed before startFile() (for sheet 1) and between newSheet() calls
+        // (to give each manually-rotated sheet its own header style).
         $this->headerStyleId = $this->styles->registerHeaderStyle($options);
 
         return $this;
@@ -303,6 +305,9 @@ abstract class BaseXlsxWriter
      */
     public function setColumnFormat(int $column, string $presetOrCode): self
     {
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
+        }
         if ($column < 1) {
             throw new XlsxStreamException("Column index must be >= 1, got {$column}.");
         }
@@ -349,9 +354,10 @@ abstract class BaseXlsxWriter
         $this->columns = $headers;
         $this->started = true;
 
-        // Write only static files that don't depend on sheet count
+        // Static files that don't depend on sheet count or registry state.
+        // styles.xml is deferred to finishFile() so styles registered between
+        // newSheet() calls (or during streaming) are all included.
         $this->writeStaticFile('_rels/.rels', $this->getRelsXml());
-        $this->writeStaticFile('xl/styles.xml', $this->getStylesXml());
     }
 
     /**
@@ -716,11 +722,13 @@ abstract class BaseXlsxWriter
     {
         $cells = [];
         $colIndex = 1;
+        // Hoist the styles-empty check so the fast (unstyled) path skips the
+        // per-cell lookup entirely — matches v2.0.1 hot-path cost.
         $hasColumnStyles = ! empty($this->columnStyleIds);
 
         foreach ($data as $value) {
             $cellRef = $this->getColumnLetter($colIndex) . $rowIndex;
-            $colStyleId = $hasColumnStyles ? ($this->columnStyleIds[$colIndex] ?? null) : null;
+            $col = $colIndex;
             $colIndex++;
 
             // Null / empty string -> empty cell
@@ -739,15 +747,20 @@ abstract class BaseXlsxWriter
             // (column-specific format wins if set, else fallback to legacy STYLE_DATETIME)
             if ($value instanceof \DateTimeInterface) {
                 $serial = ($value->getTimestamp() - self::EXCEL_EPOCH_TIMESTAMP) / 86400;
-                $styleId = $colStyleId ?? self::STYLE_DATETIME;
+                $styleId = $hasColumnStyles && isset($this->columnStyleIds[$col])
+                    ? $this->columnStyleIds[$col]
+                    : self::STYLE_DATETIME;
                 $cells[] = '<c r="' . $cellRef . '" s="' . $styleId . '" t="n"><v>' . $serial . '</v></c>';
                 continue;
             }
 
-            // Numeric values
+            // Numeric values — split fast/slow so unstyled exports keep v2.0.1 cost
             if (is_int($value) || is_float($value)) {
-                $styleAttr = $colStyleId !== null ? ' s="' . $colStyleId . '"' : '';
-                $cells[] = '<c r="' . $cellRef . '"' . $styleAttr . ' t="n"><v>' . $value . '</v></c>';
+                if ($hasColumnStyles && isset($this->columnStyleIds[$col])) {
+                    $cells[] = '<c r="' . $cellRef . '" s="' . $this->columnStyleIds[$col] . '" t="n"><v>' . $value . '</v></c>';
+                } else {
+                    $cells[] = '<c r="' . $cellRef . '" t="n"><v>' . $value . '</v></c>';
+                }
                 continue;
             }
 
@@ -756,9 +769,10 @@ abstract class BaseXlsxWriter
                 if ($this->shouldPreserveNumericString($value)) {
                     $escaped = $this->fastXmlEscape($value);
                     $cells[] = '<c r="' . $cellRef . '" t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+                } elseif ($hasColumnStyles && isset($this->columnStyleIds[$col])) {
+                    $cells[] = '<c r="' . $cellRef . '" s="' . $this->columnStyleIds[$col] . '" t="n"><v>' . (0 + $value) . '</v></c>';
                 } else {
-                    $styleAttr = $colStyleId !== null ? ' s="' . $colStyleId . '"' : '';
-                    $cells[] = '<c r="' . $cellRef . '"' . $styleAttr . ' t="n"><v>' . (0 + $value) . '</v></c>';
+                    $cells[] = '<c r="' . $cellRef . '" t="n"><v>' . (0 + $value) . '</v></c>';
                 }
                 continue;
             }
@@ -954,6 +968,7 @@ abstract class BaseXlsxWriter
             $this->finishCurrentSheet();
         }
 
+        $this->writeStaticFile('xl/styles.xml', $this->getStylesXml());
         $this->writeStaticFile('xl/_rels/workbook.xml.rels', $this->getWorkbookRelsXml());
         $this->writeStaticFile('xl/workbook.xml', $this->getWorkbookXml());
         $this->writeStaticFile('[Content_Types].xml', $this->getContentTypesXml());

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -92,6 +92,9 @@ abstract class BaseXlsxWriter
     protected array $columnWidths = [];
     protected bool $autoColumnWidth = false;
 
+    // Custom sheet name for the next sheet rotation (set by newSheet()).
+    protected ?string $nextSheetName = null;
+
     public function __construct()
     {
         $this->styles = new StyleRegistry();
@@ -410,6 +413,53 @@ abstract class BaseXlsxWriter
     }
 
     /**
+     * Start a new named sheet, optionally with its own header row.
+     *
+     *   $writer->startFile(['ID', 'Name']);
+     *   $writer->writeRow([1, 'Alice']);
+     *   $writer->newSheet('Orders', ['ID', 'Customer', 'Total']);
+     *   $writer->writeRow([100, 1, 49.90]);
+     *
+     * The current sheet is finalized first (if it has any rows). The new
+     * sheet is created eagerly so it shows up in the output even if no
+     * data rows follow.
+     *
+     * If $headers is null the previous header row is reused.
+     */
+    public function newSheet(string $name, ?array $headers = null): self
+    {
+        if (! $this->started) {
+            throw XlsxStreamException::headersNotSet();
+        }
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
+        }
+        if ($name === '') {
+            throw new XlsxStreamException('Sheet name cannot be empty.');
+        }
+
+        // Finalize the current sheet so its data descriptor and central-dir
+        // entry are committed before we start writing the next sheet.
+        if ($this->currentSheetRow > 0) {
+            $this->flushRowBuffer();
+            $this->finishCurrentSheet();
+        }
+
+        if ($headers !== null) {
+            if (count($headers) > self::MAX_COLUMNS) {
+                throw XlsxStreamException::tooManyColumns(count($headers), self::MAX_COLUMNS);
+            }
+            $this->columns = $headers;
+        }
+
+        $this->nextSheetName = $name;
+        $this->currentSheetIndex++;
+        $this->startNewSheet();
+
+        return $this;
+    }
+
+    /**
      * Flush row buffer to stream
      */
     protected function flushRowBuffer(): void
@@ -440,9 +490,15 @@ abstract class BaseXlsxWriter
      */
     protected function startNewSheet(): void
     {
-        $sheetName = "Sheet{$this->currentSheetIndex}";
-        if ($this->currentSheetIndex === 1) {
+        // Custom name (from newSheet()) wins, else preserve the legacy default
+        // ("Report" for the first sheet, "SheetN" for auto-split overflow).
+        if ($this->nextSheetName !== null) {
+            $sheetName = $this->nextSheetName;
+            $this->nextSheetName = null;
+        } elseif ($this->currentSheetIndex === 1) {
             $sheetName = 'Report';
+        } else {
+            $sheetName = "Sheet{$this->currentSheetIndex}";
         }
 
         $sheetName = $this->sanitizeSheetName($sheetName);

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -83,6 +83,11 @@ abstract class BaseXlsxWriter
     /** @var array<int, int> 1-based column index => cellXfs style id */
     protected array $columnStyleIds = [];
 
+    // Sheet view options (v2.2+)
+    protected int $freezeRows = 0;
+    protected int $freezeColumns = 0;
+    protected bool $autoFilterEnabled = false;
+
     public function __construct()
     {
         $this->styles = new StyleRegistry();
@@ -179,6 +184,51 @@ abstract class BaseXlsxWriter
             throw new XlsxStreamException('setHeaderStyle() must be called before startFile().');
         }
         $this->headerStyleId = $this->styles->registerHeaderStyle($options);
+
+        return $this;
+    }
+
+    /**
+     * Freeze the first row so it stays visible while scrolling.
+     *
+     * Equivalent to Excel's "View > Freeze Top Row".
+     */
+    public function freezeFirstRow(): self
+    {
+        return $this->freezeRowsAndColumns(1, 0);
+    }
+
+    /**
+     * Freeze a custom number of rows and/or columns.
+     *
+     *   $writer->freezeRowsAndColumns(rows: 1, columns: 2);
+     */
+    public function freezeRowsAndColumns(int $rows = 1, int $columns = 0): self
+    {
+        if ($this->started) {
+            throw new XlsxStreamException('freezeRowsAndColumns() must be called before startFile().');
+        }
+        if ($rows < 0 || $columns < 0) {
+            throw new XlsxStreamException('Freeze rows/columns must be >= 0.');
+        }
+        $this->freezeRows = $rows;
+        $this->freezeColumns = $columns;
+
+        return $this;
+    }
+
+    /**
+     * Add Excel's auto-filter dropdowns to the header row.
+     *
+     * The filter range is computed automatically from the sheet's columns
+     * and final row count when the sheet is closed.
+     */
+    public function enableAutoFilter(): self
+    {
+        if ($this->started) {
+            throw new XlsxStreamException('enableAutoFilter() must be called before startFile().');
+        }
+        $this->autoFilterEnabled = true;
 
         return $this;
     }
@@ -386,6 +436,7 @@ abstract class BaseXlsxWriter
         // Write sheet header
         $sheetHeader = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
         $sheetHeader .= '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">';
+        $sheetHeader .= $this->buildSheetViewsXml();
         $sheetHeader .= '<sheetData>';
 
         if (!empty($this->columns)) {
@@ -420,13 +471,61 @@ abstract class BaseXlsxWriter
     }
 
     /**
+     * Build the <sheetViews> block when freeze panes are configured.
+     * Must appear BEFORE <sheetData> per OOXML schema order.
+     */
+    protected function buildSheetViewsXml(): string
+    {
+        if ($this->freezeRows === 0 && $this->freezeColumns === 0) {
+            return '';
+        }
+
+        $topLeftCol = $this->getColumnLetter($this->freezeColumns + 1);
+        $topLeftRow = $this->freezeRows + 1;
+        $topLeftCell = $topLeftCol.$topLeftRow;
+
+        $activePane = match (true) {
+            $this->freezeRows > 0 && $this->freezeColumns > 0 => 'bottomRight',
+            $this->freezeRows > 0 => 'bottomLeft',
+            default => 'topRight',
+        };
+
+        $pane = '<pane';
+        if ($this->freezeColumns > 0) {
+            $pane .= ' xSplit="'.$this->freezeColumns.'"';
+        }
+        if ($this->freezeRows > 0) {
+            $pane .= ' ySplit="'.$this->freezeRows.'"';
+        }
+        $pane .= ' topLeftCell="'.$topLeftCell.'" activePane="'.$activePane.'" state="frozen"/>';
+
+        return '<sheetViews><sheetView workbookViewId="0">'.$pane.'</sheetView></sheetViews>';
+    }
+
+    /**
+     * Build the <autoFilter> element written AFTER </sheetData>.
+     * Range covers all populated rows and the configured column count.
+     */
+    protected function buildAutoFilterXml(): string
+    {
+        if (! $this->autoFilterEnabled || empty($this->columns) || $this->currentSheetRow < 1) {
+            return '';
+        }
+
+        $lastCol = $this->getColumnLetter(count($this->columns));
+        $range = 'A1:'.$lastCol.$this->currentSheetRow;
+
+        return '<autoFilter ref="'.$range.'"/>';
+    }
+
+    /**
      * Finish current sheet
      */
     protected function finishCurrentSheet(): void
     {
         $this->flushRowBuffer();
 
-        $sheetFooter = '</sheetData></worksheet>';
+        $sheetFooter = '</sheetData>'.$this->buildAutoFilterXml().'</worksheet>';
 
         hash_update($this->crcContext, $sheetFooter);
         $this->sheetUncompressedSize += strlen($sheetFooter);

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -88,6 +88,10 @@ abstract class BaseXlsxWriter
     protected int $freezeColumns = 0;
     protected bool $autoFilterEnabled = false;
 
+    /** @var array<int, float> 1-based column index => width in characters */
+    protected array $columnWidths = [];
+    protected bool $autoColumnWidth = false;
+
     public function __construct()
     {
         $this->styles = new StyleRegistry();
@@ -213,6 +217,54 @@ abstract class BaseXlsxWriter
         }
         $this->freezeRows = $rows;
         $this->freezeColumns = $columns;
+
+        return $this;
+    }
+
+    /**
+     * Set explicit column widths in Excel character units.
+     *
+     *   $writer->setColumnWidths([1 => 8, 2 => 30, 3 => 15]);
+     *
+     * Keys are 1-based column indexes. Columns omitted from the array
+     * fall back to Excel's default width.
+     *
+     * @param array<int, float|int> $widths
+     */
+    public function setColumnWidths(array $widths): self
+    {
+        if ($this->started) {
+            throw new XlsxStreamException('setColumnWidths() must be called before startFile().');
+        }
+        foreach ($widths as $col => $width) {
+            if ($col < 1) {
+                throw new XlsxStreamException("Column index must be >= 1, got {$col}.");
+            }
+            if ($width <= 0) {
+                throw new XlsxStreamException("Column width must be > 0, got {$width}.");
+            }
+            $this->columnWidths[$col] = (float) $width;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Auto-size columns from the header text.
+     *
+     * Heuristic: width = max(8, mb_strlen(header) + 2). Cheap, no
+     * per-row sampling, no streaming impact. Manual setColumnWidths()
+     * entries override the heuristic for the columns they cover.
+     *
+     * For sample-based auto-fit (scanning N rows of data), wait for
+     * a future release.
+     */
+    public function setAutoColumnWidth(bool $enabled = true): self
+    {
+        if ($this->started) {
+            throw new XlsxStreamException('setAutoColumnWidth() must be called before startFile().');
+        }
+        $this->autoColumnWidth = $enabled;
 
         return $this;
     }
@@ -437,6 +489,7 @@ abstract class BaseXlsxWriter
         $sheetHeader = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
         $sheetHeader .= '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">';
         $sheetHeader .= $this->buildSheetViewsXml();
+        $sheetHeader .= $this->buildColsXml();
         $sheetHeader .= '<sheetData>';
 
         if (!empty($this->columns)) {
@@ -500,6 +553,44 @@ abstract class BaseXlsxWriter
         $pane .= ' topLeftCell="'.$topLeftCell.'" activePane="'.$activePane.'" state="frozen"/>';
 
         return '<sheetViews><sheetView workbookViewId="0">'.$pane.'</sheetView></sheetViews>';
+    }
+
+    /**
+     * Build the <cols> block emitted between <sheetViews> and <sheetData>.
+     *
+     * Resolution order (per column):
+     *   1. Explicit width from setColumnWidths()
+     *   2. Heuristic from header text length when setAutoColumnWidth(true)
+     *   3. Excel default (no <col> entry)
+     */
+    protected function buildColsXml(): string
+    {
+        $resolved = [];
+        $columnCount = count($this->columns);
+
+        foreach (range(1, max($columnCount, max(array_keys($this->columnWidths) ?: [0]))) as $col) {
+            if (isset($this->columnWidths[$col])) {
+                $resolved[$col] = $this->columnWidths[$col];
+
+                continue;
+            }
+            if ($this->autoColumnWidth && isset($this->columns[$col - 1])) {
+                $headerLen = mb_strlen((string) $this->columns[$col - 1], 'UTF-8');
+                $resolved[$col] = (float) max(8, $headerLen + 2);
+            }
+        }
+
+        if (empty($resolved)) {
+            return '';
+        }
+
+        $xml = '<cols>';
+        foreach ($resolved as $col => $width) {
+            $xml .= '<col min="'.$col.'" max="'.$col.'" width="'.$width.'" customWidth="1"/>';
+        }
+        $xml .= '</cols>';
+
+        return $xml;
     }
 
     /**

--- a/src/Writers/SinkableXlsxWriter.php
+++ b/src/Writers/SinkableXlsxWriter.php
@@ -135,6 +135,7 @@ class SinkableXlsxWriter extends BaseXlsxWriter
                 $this->finishCurrentSheet();
             }
 
+            $this->writeStaticFile('xl/styles.xml', $this->getStylesXml());
             $this->writeStaticFile('xl/_rels/workbook.xml.rels', $this->getWorkbookRelsXml());
             $this->writeStaticFile('xl/workbook.xml', $this->getWorkbookXml());
             $this->writeStaticFile('[Content_Types].xml', $this->getContentTypesXml());

--- a/src/Writers/SinkableXlsxWriter.php
+++ b/src/Writers/SinkableXlsxWriter.php
@@ -20,6 +20,7 @@ class SinkableXlsxWriter extends BaseXlsxWriter
 
     public function __construct(Sink $sink)
     {
+        parent::__construct();
         $this->sink = $sink;
     }
 

--- a/tests/V22StylingTest.php
+++ b/tests/V22StylingTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests;
+
+use Kolay\XlsxStream\Exceptions\XlsxStreamException;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+use ZipArchive;
+
+class V22StylingTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/v22_'.uniqid().'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+        parent::tearDown();
+    }
+
+    // ── Header styling ──────────────────────────────────────────────
+
+    public function test_header_style_applied_to_header_row()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setHeaderStyle(['bold' => true, 'fill' => '#4F81BD', 'color' => '#FFFFFF']);
+        $writer->startFile(['Name', 'Email']);
+        $writer->writeRow(['Alice', 'a@x.com']);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $styles = $this->extract('xl/styles.xml');
+
+        // Header row carries a style id (s="N") that data rows don't
+        $this->assertMatchesRegularExpression('#<row r="1">.*<c r="A1" s="\d+"#', $sheet);
+        $this->assertStringContainsString('<b/>', $styles);
+        $this->assertStringContainsString('rgb="FF4F81BD"', $styles);
+        $this->assertStringContainsString('rgb="FFFFFFFF"', $styles);
+    }
+
+    public function test_header_style_can_be_changed_between_sheets()
+    {
+        // Each newSheet() can have its own header style — the registry
+        // accumulates styles, the writer just records the most recent id.
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setHeaderStyle(['bold' => true, 'fill' => '#4F81BD']);
+        $writer->startFile(['A']);
+        $writer->writeRow([1]);
+
+        $writer->setHeaderStyle(['bold' => true, 'fill' => '#9BBB59']);
+        $writer->newSheet('Second', ['B']);
+        $writer->writeRow([2]);
+        $stats = $writer->finishFile();
+
+        $this->assertEquals(2, $stats['sheets']);
+
+        $styles = $this->extract('xl/styles.xml');
+        $this->assertStringContainsString('rgb="FF4F81BD"', $styles);
+        $this->assertStringContainsString('rgb="FF9BBB59"', $styles);
+    }
+
+    // ── Column formats ──────────────────────────────────────────────
+
+    public function test_set_column_format_preset_date()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(2, 'date');
+        $writer->startFile(['ID', 'Born']);
+        $writer->writeRow([1, new \DateTime('2026-01-15', new \DateTimeZone('UTC'))]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $styles = $this->extract('xl/styles.xml');
+
+        // Cell B2 (Born column) carries the date style id
+        $this->assertMatchesRegularExpression('#<c r="B2" s="\d+" t="n"><v>46037</v>#', $sheet);
+        $this->assertStringContainsString('formatCode="yyyy-mm-dd"', $styles);
+    }
+
+    public function test_set_column_format_preset_currency_try()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(1, 'currency_try');
+        $writer->startFile(['Price']);
+        $writer->writeRow([99.50]);
+        $writer->finishFile();
+
+        $styles = $this->extract('xl/styles.xml');
+        $this->assertStringContainsString('₺', $styles);
+    }
+
+    public function test_set_column_format_custom_format_code()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(1, '0.000');
+        $writer->startFile(['Precise']);
+        $writer->writeRow([3.14159]);
+        $writer->finishFile();
+
+        $styles = $this->extract('xl/styles.xml');
+        $this->assertStringContainsString('formatCode="0.000"', $styles);
+    }
+
+    public function test_set_column_format_dedupes_same_code()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(1, 'date');
+        $writer->setColumnFormat(2, 'date'); // same preset → same style id
+        $writer->startFile(['A', 'B']);
+        $writer->writeRow([1, 2]);
+        $writer->finishFile();
+
+        $styles = $this->extract('xl/styles.xml');
+        // 'yyyy-mm-dd' should appear only once in <numFmts>
+        $count = substr_count($styles, 'formatCode="yyyy-mm-dd"');
+        $this->assertEquals(1, $count, 'Same format code must be registered once');
+    }
+
+    public function test_set_column_format_rejects_invalid_column()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $this->expectException(XlsxStreamException::class);
+        $writer->setColumnFormat(0, 'date');
+    }
+
+    public function test_string_cells_are_unaffected_by_column_format()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(1, 'currency_try');
+        $writer->startFile(['Mixed']);
+        $writer->writeRow(['hello']);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // String cells stay inlineStr without a style id
+        $this->assertStringContainsString('<c r="A2" t="inlineStr">', $sheet);
+        $this->assertStringNotContainsString('<c r="A2" s=', $sheet);
+    }
+
+    // ── Freeze pane ─────────────────────────────────────────────────
+
+    public function test_freeze_first_row_emits_pane()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->freezeFirstRow();
+        $writer->startFile(['A']);
+        $writer->writeRow([1]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringContainsString('<sheetViews>', $sheet);
+        $this->assertStringContainsString('ySplit="1"', $sheet);
+        $this->assertStringContainsString('topLeftCell="A2"', $sheet);
+        $this->assertStringContainsString('state="frozen"', $sheet);
+    }
+
+    public function test_freeze_rows_and_columns()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->freezeRowsAndColumns(rows: 2, columns: 3);
+        $writer->startFile(['A', 'B', 'C', 'D']);
+        $writer->writeRow([1, 2, 3, 4]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringContainsString('xSplit="3"', $sheet);
+        $this->assertStringContainsString('ySplit="2"', $sheet);
+        $this->assertStringContainsString('topLeftCell="D3"', $sheet);
+    }
+
+    public function test_no_freeze_pane_when_unset()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['A']);
+        $writer->writeRow([1]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringNotContainsString('<sheetViews>', $sheet);
+    }
+
+    // ── Auto filter ─────────────────────────────────────────────────
+
+    public function test_auto_filter_emits_range_after_sheet_data()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->enableAutoFilter();
+        $writer->startFile(['ID', 'Name', 'Email']);
+        for ($i = 1; $i <= 5; $i++) {
+            $writer->writeRow([$i, "User $i", "u$i@x.com"]);
+        }
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // Range covers all populated rows (header + 5 data = 6)
+        $this->assertStringContainsString('<autoFilter ref="A1:C6"/>', $sheet);
+        // <autoFilter> must appear AFTER </sheetData>
+        $this->assertGreaterThan(
+            strpos($sheet, '</sheetData>'),
+            strpos($sheet, '<autoFilter')
+        );
+    }
+
+    // ── Column widths ───────────────────────────────────────────────
+
+    public function test_explicit_column_widths()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnWidths([1 => 8, 2 => 30, 3 => 15.5]);
+        $writer->startFile(['ID', 'Name', 'Phone']);
+        $writer->writeRow([1, 'Alice', '+90555']);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringContainsString('<col min="1" max="1" width="8"', $sheet);
+        $this->assertStringContainsString('<col min="2" max="2" width="30"', $sheet);
+        $this->assertStringContainsString('<col min="3" max="3" width="15.5"', $sheet);
+    }
+
+    public function test_auto_column_width_uses_header_length()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth();
+        $writer->startFile(['ID', 'Customer Email Address']);
+        $writer->writeRow([1, 'a@x.com']);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // 'ID' (2 chars) → max(8, 4) = 8
+        $this->assertStringContainsString('<col min="1" max="1" width="8"', $sheet);
+        // 'Customer Email Address' (22 chars) → max(8, 24) = 24
+        $this->assertStringContainsString('<col min="2" max="2" width="24"', $sheet);
+    }
+
+    public function test_manual_widths_override_auto()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth();
+        $writer->setColumnWidths([1 => 50]); // override col 1
+        $writer->startFile(['ID', 'Name']);
+        $writer->writeRow([1, 'x']);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringContainsString('<col min="1" max="1" width="50"', $sheet);
+        // Col 2 still gets auto width (4 chars 'Name' → max(8, 6) = 8)
+        $this->assertStringContainsString('<col min="2" max="2" width="8"', $sheet);
+    }
+
+    public function test_no_cols_block_when_widths_unset()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['A']);
+        $writer->writeRow([1]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringNotContainsString('<cols>', $sheet);
+    }
+
+    // ── newSheet manual multi-sheet ────────────────────────────────
+
+    public function test_new_sheet_creates_named_sheet_with_new_headers()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['ID', 'Name']);
+        $writer->writeRow([1, 'Alice']);
+        $writer->newSheet('Orders', ['OrderID', 'Total']);
+        $writer->writeRow([100, 49.90]);
+        $stats = $writer->finishFile();
+
+        $this->assertEquals(2, $stats['sheets']);
+        $this->assertEquals('Report', $stats['sheet_details'][0]['name']);
+        $this->assertEquals('Orders', $stats['sheet_details'][1]['name']);
+
+        // Verify both sheets exist
+        $zip = new ZipArchive();
+        $zip->open($this->testFile);
+        $sheet1 = $zip->getFromName('xl/worksheets/sheet1.xml');
+        $sheet2 = $zip->getFromName('xl/worksheets/sheet2.xml');
+        $zip->close();
+
+        $this->assertStringContainsString('<t>ID</t>', $sheet1);
+        $this->assertStringContainsString('<t>OrderID</t>', $sheet2);
+    }
+
+    public function test_new_sheet_reuses_headers_when_not_specified()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['ID', 'Name']);
+        $writer->writeRow([1, 'A']);
+        $writer->newSheet('Q2');
+        $writer->writeRow([2, 'B']);
+        $stats = $writer->finishFile();
+
+        $this->assertEquals(2, $stats['sheets']);
+        $zip = new ZipArchive();
+        $zip->open($this->testFile);
+        $sheet2 = $zip->getFromName('xl/worksheets/sheet2.xml');
+        $zip->close();
+
+        // Same headers on Q2
+        $this->assertStringContainsString('<t>ID</t>', $sheet2);
+        $this->assertStringContainsString('<t>Name</t>', $sheet2);
+    }
+
+    public function test_new_sheet_before_start_file_throws()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $this->expectException(XlsxStreamException::class);
+        $writer->newSheet('Foo');
+    }
+
+    public function test_new_sheet_after_finish_throws()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['A']);
+        $writer->writeRow([1]);
+        $writer->finishFile();
+
+        $this->expectException(XlsxStreamException::class);
+        $writer->newSheet('Foo');
+    }
+
+    public function test_new_sheet_empty_name_rejected()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['A']);
+        $this->expectException(XlsxStreamException::class);
+        $writer->newSheet('');
+    }
+
+    // ── End-to-end integrity ────────────────────────────────────────
+
+    public function test_full_styling_produces_valid_xlsx()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer
+            ->setHeaderStyle(['bold' => true, 'fill' => '#4F81BD', 'color' => '#FFFFFF'])
+            ->setColumnFormat(2, 'date')
+            ->setColumnFormat(3, 'currency_try')
+            ->setColumnFormat(4, 'percent')
+            ->setColumnWidths([1 => 8, 2 => 14, 3 => 14, 4 => 10])
+            ->freezeFirstRow()
+            ->enableAutoFilter();
+
+        $writer->startFile(['ID', 'Date', 'Price', 'Discount']);
+        for ($i = 1; $i <= 50; $i++) {
+            $writer->writeRow([
+                $i,
+                new \DateTime("2026-0".(($i % 9) + 1)."-01", new \DateTimeZone('UTC')),
+                99.99 + $i,
+                ($i % 100) / 100,
+            ]);
+        }
+
+        $writer->newSheet('Summary', ['Metric', 'Value']);
+        $writer->writeRow(['Total', 100]);
+        $writer->writeRow(['Average', 50.5]);
+        $stats = $writer->finishFile();
+
+        $this->assertEquals(2, $stats['sheets']);
+        $this->assertEquals(52, $stats['rows']);
+
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($this->testFile, ZipArchive::CHECKCONS) === true);
+        $zip->close();
+    }
+
+    // ── helper ──────────────────────────────────────────────────────
+
+    private function extract(string $entry): string
+    {
+        $zip = new ZipArchive();
+        $zip->open($this->testFile);
+        $content = $zip->getFromName($entry);
+        $zip->close();
+
+        return $content;
+    }
+}

--- a/tests/V22StylingTest.php
+++ b/tests/V22StylingTest.php
@@ -239,6 +239,33 @@ class V22StylingTest extends TestCase
         $this->assertStringContainsString('<col min="2" max="2" width="24"', $sheet);
     }
 
+    public function test_auto_column_width_respects_format_minimum()
+    {
+        // Short header 'Salary' (6 chars) on a currency column should still
+        // render the value ('₺99,999.00' = 10+ chars) without being clipped.
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth();
+        $writer->setColumnFormat(2, 'currency_try');
+        $writer->setColumnFormat(3, 'datetime');
+        $writer->setColumnFormat(4, 'date');
+        $writer->setColumnFormat(5, 'percent');
+        $writer->startFile(['ID', 'Salary', 'Last Active', 'Date', 'Done']);
+        $writer->writeRow([1, 50000, new \DateTime('2026-01-15 10:30:00'), new \DateTime('2026-01-15'), 0.5]);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // ID (no format): max(8, 4) = 8
+        $this->assertStringContainsString('<col min="1" max="1" width="8"', $sheet);
+        // Salary (currency_try, header 6 → 8): format min 14 wins
+        $this->assertStringContainsString('<col min="2" max="2" width="14"', $sheet);
+        // Last Active (datetime, header 11 → 13): format min 20 wins
+        $this->assertStringContainsString('<col min="3" max="3" width="20"', $sheet);
+        // Date (date, header 4 → 8): format min 12 wins
+        $this->assertStringContainsString('<col min="4" max="4" width="12"', $sheet);
+        // Done (percent, header 4 → 8): format min 10 wins
+        $this->assertStringContainsString('<col min="5" max="5" width="10"', $sheet);
+    }
+
     public function test_manual_widths_override_auto()
     {
         $writer = new SinkableXlsxWriter(new FileSink($this->testFile));


### PR DESCRIPTION
v2.2 brings the styling surface that was on the v2.x roadmap. Opt-in for         
  every feature — unstyled exports keep the v2.1 hot-path cost.                                                                                                                          
                                                                                   
  ## Highlights               
                                      
  - `setHeaderStyle(['bold' => true, 'fill' => '#4F81BD', 'color' => '#FFFFFF'])`                                                                                                        
  - `setColumnFormat($col, $preset|$code)` with presets: `date`, `datetime`,
    `time`, `integer`, `decimal`, `percent`, `currency_try/usd/eur/gbp`,                                                                                                                 
    plus any raw Excel format code                                                 
  - `setColumnWidths()` (manual) + `setAutoColumnWidth()` (header + format-aware)                                                                                                        
  - `freezeFirstRow()` / `freezeRowsAndColumns(rows, columns)` + `enableAutoFilter()`                                                                                                    
  - `newSheet($name, $headers = null)` for true multi-sheet workbooks with                                                                                                               
    custom names + `clearColumnFormats()` between rotations                                                                                                                              
                                                                                   
  ## Performance                                                                                                                                                                         
                                                                                                                                                                                         
  Re-measured against v2.1 baseline on the same machine (Apple Silicon,                                                                                                                  
  PHP 8.2.28):                                                                                                                                                                           
                                                                                                                                                                                         
  | Workload | v2.1 baseline | Plain v2.2 | Styled v2.2 |                                                                                                                                
  |---|---|---|---|                                                                                                                                                                      
  | 1M rows local | 168K rows/s | 167K rows/s | 164K rows/s |                                                                                                                            
  | Memory | O(1) | O(1) | O(1) |                                                                                                                                                        
                                                                                                                                                                                         
  Hot-path branches on a hoisted \`\$hasColumnStyles\` flag so the unstyled        
  code path is byte-for-byte the v2.1 path. Styled exports add ~2-3%                                                                                                                     
  throughput cost and ~3% file-size cost (the \`s=\"N\"\` cell attributes).
                                                                                                                                                                                         
  The full README hybrid benchmark (May 2026) adds the comparison vs v1.x                                                                                                                
  (September 2025): S3 throughput is up ~2-3× thanks to AWS SDK 3.379+
  and the measurement network; local is ~5-10% slower than v1.x as the                                                                                                                   
  documented cost of v2.0+ per-cell type detection.                                                                                                                                      
                                                                                                                                                                                         
  ## Tests                                                                                                                                                                               
                                                                                                                                                                                         
  68 tests / 148 assertions, all green. New \`tests/V22StylingTest.php\`                                                                                                                 
  covers every styling primitive: header style applied to header row,                                                                                                                    
  column format presets and raw format codes, dedup behavior, freeze                                                                                                                     
  pane variants, auto filter range, manual + auto column widths,                                                                                                                         
  format-aware width minimums, manual newSheet flow, end-to-end full-styling                                                                                                             
  ZIP integrity check.                                                                                                                                                                   
                                                                                                                                                                                         
  ## Walkthrough                                                                                                                                                                         
                                                                                   
  1. \`feat(styling): StyleRegistry + setHeaderStyle + setColumnFormat\` —                                                                                                               
     dynamic styles.xml, deduplicated by value, fast-path-friendly                                                                                                                       
  2. \`feat(styling): freeze pane and auto filter\` — sheet view + autoFilter XML                                                                                                        
  3. \`feat(styling): manual setColumnWidths and header-based auto width\`                                                                                                               
  4. \`feat(styling): newSheet(name, headers) for true multi-sheet workbooks\`                                                                                                           
  5. \`test+example+perf: v2.2 styling coverage and fast-path split\` — 22 new                                                                                                           
     tests, comprehensive S3 example, hot-path optimization to remove the                                                                                                                
     plain regression introduced earlier in the branch                                                                                                                                   
  6. \`feat(styling): format-aware auto-width + clearColumnFormats + relaxed       
     setters\` — fixes the "Salary header is 6 chars but ₺50,000.00 needs 14                                                                                                             
     chars" \`####\` issue without falling back to sample-based scanning                                                                                                                 
  7. \`docs(v2.2): hybrid benchmark, styling tour example, CHANGELOG\` —                                                                                                                 
     May 2026 v2.2 numbers added next to the historical Sept 2025 table                                                                                                                  
                                                                                                                                                                                         
  ## Manual smoke test                                                                                                                                                                   
                                                                                                                                                                                         
  The expanded \`examples/s3-streaming.php\` was uploaded to the test bucket                                                                                                             
  (\`s3://xlsx-test-package/examples/styling-tour-*.xlsx\`) and downloaded                                                                                                               
  back; ZipArchive::CHECKCONS passes and the file opens cleanly in Excel                                                                                                                 
  (verified header coloring, frozen pane, auto-filter dropdowns, currency                                                                                                                
  \`₺\` rendering, sortable date cells, native percent format).  