### PR TITLE
fix: XML control-byte sanitization fast-path bypass + perf win (v2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to `kolay/xlsx-stream` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] — 2026-05-03
+
+### Fixed
+
+- **XML control-byte sanitization bypass** — `fastXmlEscape()` used a
+  single-quoted needle for `strpbrk()`, so `\x00`, `\x01`, … escapes
+  were embedded as the literal characters `\`, `x`, `0`, `1`, …
+  instead of as actual control bytes. Strings whose characters didn't
+  overlap with `&<>"'\x0..9A..F` (e.g. pure-lowercase Latin or
+  multi-byte UTF-8 with embedded nulls) bypassed sanitization entirely
+  and Excel rejected the workbook with `Char 0x0 out of allowed
+  range`. The needle is now a double-quoted string so the escape
+  sequences resolve correctly. Pre-existing bug going back to v1.x.
+
+### Performance (side effect of the fix)
+
+- The buggy needle was a 129-character literal that `strpbrk()` had to
+  compare each input character against on the fast path. The corrected
+  needle is 36 characters (5 special chars + 31 actual control bytes),
+  so the per-cell sanitization check is ~3.5× cheaper. Comprehensive
+  benchmark on the same machine and workload as the v2.2 baseline:
+  - 1M rows local: **210K rows/s** (was 161K in v2.2 / 169K in v2.2.1)
+    — **+30% over v2.2**, **+15% over v1.x baseline**
+  - 4.5M rows S3: **130K rows/s** (was 107K in v2.2) — **+22%**
+  - Memory unchanged — local stays at 0–2 MB constant, S3 sawtooth
+    pattern unchanged.
+
+  The README's "Latest Benchmark" table has been refreshed with the
+  full v2.2.2 numbers and the "What changed since v1.x" notes flipped
+  from "v2.x is ~5–10% slower locally" to "v2.x is now ~15–25% faster
+  locally".
+
+### Documentation
+
+- README's `onProgress` section now notes that `$bytes` only advances
+  when zlib emits compressed output. With small datasets (or large
+  `setBufferFlushInterval()` relative to `setProgressInterval()`),
+  consecutive events may report the same byte count between flushes.
+  The row counter is always exact.
+
+### Tests
+
+- New `tests/XmlSanitizationTest.php` — 6 cases: pure-lowercase with
+  null byte, full-control-byte input across the C0 set, mixed-case
+  with control bytes, headers with control bytes, preservation of
+  `\t` `\n` `\r` (valid XML chars), and the slow-path `&<>"'`
+  escape sanity check. All assertions include a `libxml`-strict parse
+  to match Excel's behavior.
+
 ## [2.2.1] — 2026-05-03
 
 ### Added — polish
@@ -194,6 +243,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: high-performance XLSX streaming writer with FileSink and
   S3MultipartSink, multi-sheet support, and configurable compression.
 
+[2.2.2]: https://github.com/turgutahmet/kolay-xlsx-stream/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/turgutahmet/kolay-xlsx-stream/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/turgutahmet/kolay-xlsx-stream/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/turgutahmet/kolay-xlsx-stream/compare/v2.0.1...v2.1.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most PHP Excel libraries (PHPSpreadsheet, Spout, Laravel Excel) have critical li
 
 ## Performance Comparison
 
-### Latest Benchmark — v2.2 (May 2026)
+### Latest Benchmark — v2.2.2 (May 2026)
 
 Re-measured on an Apple Silicon laptop with PHP 8.2.28 and AWS SDK
 3.379 against the same `xlsx-test-package` bucket in `us-east-2`. The
@@ -36,35 +36,38 @@ mixed types, compression level 1).
 
 | Rows | Local Speed | Local Time | S3 Speed | S3 Memory | S3 Time | File Size |
 |------|-------------|------------|----------|-----------|---------|-----------|
-| 100 | 33,784 rows/s | 0.00s | 106 rows/s | 0 MB | 0.94s | 0.01 MB |
-| 500 | 153,942 rows/s | 0.00s | 481 rows/s | 0 MB | 1.04s | 0.02 MB |
-| 1,000 | 152,792 rows/s | 0.01s | 875 rows/s | 0 MB | 1.14s | 0.04 MB |
-| 5,000 | 160,639 rows/s | 0.03s | 3,342 rows/s | 0 MB | 1.50s | 0.2 MB |
-| 10,000 | 163,765 rows/s | 0.06s | 4,726 rows/s | 0 MB | 2.12s | 0.4 MB |
-| 25,000 | 173,144 rows/s | 0.14s | 11,357 rows/s | 0 MB | 2.20s | 1 MB |
-| 50,000 | 175,682 rows/s | 0.28s | 20,014 rows/s | 2 MB | 2.50s | 2 MB |
-| 100,000 | 175,130 rows/s | 0.57s | 22,372 rows/s | 4 MB | 4.47s | 4 MB |
-| 250,000 | 170,788 rows/s | 1.46s | 62,340 rows/s | 12 MB (±6) | 4.01s | 10 MB |
-| 500,000 | 171,361 rows/s | 2.92s | 83,525 rows/s | 20 MB (±18) | 5.99s | 20 MB |
-| 750,000 | 168,742 rows/s | 4.44s | 93,753 rows/s | 30 MB (±26) | 8.00s | 30 MB |
-| 1,000,000 | 161,250 rows/s | 6.20s | 95,070 rows/s | 40 MB (±38) | 10.52s | 40 MB |
-| 1,500,000 | 168,616 rows/s | 8.90s | 103,311 rows/s | 60 MB (±58) | 14.52s | 60 MB |
-| 2,000,000 | 166,369 rows/s | 12.02s | 95,629 rows/s | 79 MB (±77) | 20.91s | 79 MB |
-| 3,000,000 | – | – | 105,291 rows/s | 119 MB (±117) | 28.49s | 119 MB |
-| 4,000,000 | – | – | 106,815 rows/s | 158 MB (±156) | 37.45s | 158 MB |
-| 4,500,000 | – | – | 106,715 rows/s | 178 MB (±178) | 42.17s | 178 MB |
+| 100 | 45,290 rows/s | 0.00s | 112 rows/s | 0 MB | 0.89s | 0.01 MB |
+| 500 | 191,346 rows/s | 0.00s | 491 rows/s | 0 MB | 1.02s | 0.02 MB |
+| 1,000 | 184,836 rows/s | 0.01s | 966 rows/s | 0 MB | 1.03s | 0.04 MB |
+| 5,000 | 195,825 rows/s | 0.03s | 3,345 rows/s | 0 MB | 1.49s | 0.2 MB |
+| 10,000 | 198,898 rows/s | 0.05s | 2,551 rows/s | 0 MB | 3.92s | 0.4 MB |
+| 25,000 | 210,498 rows/s | 0.12s | 10,170 rows/s | 0 MB | 2.46s | 1 MB |
+| 50,000 | 217,123 rows/s | 0.23s | 15,597 rows/s | 2 MB | 3.21s | 2 MB |
+| 100,000 | 188,771 rows/s | 0.53s | 24,258 rows/s | 4 MB | 4.12s | 4 MB |
+| 250,000 | 215,340 rows/s | 1.16s | 63,713 rows/s | 12 MB (±6) | 3.92s | 10 MB |
+| 500,000 | 209,428 rows/s | 2.39s | 87,679 rows/s | 20 MB (±18) | 5.70s | 20 MB |
+| 750,000 | 211,315 rows/s | 3.55s | 84,221 rows/s | 30 MB (±26) | 8.91s | 30 MB |
+| 1,000,000 | 209,905 rows/s | 4.76s | 106,924 rows/s | 40 MB (±38) | 9.35s | 40 MB |
+| 1,500,000 | 207,503 rows/s | 7.23s | 117,631 rows/s | 60 MB (±58) | 12.75s | 60 MB |
+| 2,000,000 | 208,512 rows/s | 9.59s | 112,708 rows/s | 79 MB (±77) | 17.74s | 79 MB |
+| 3,000,000 | – | – | 112,229 rows/s | 119 MB (±117) | 26.73s | 119 MB |
+| 4,000,000 | – | – | 128,930 rows/s | 160 MB (±156) | 31.02s | 158 MB |
+| 4,500,000 | – | – | 130,293 rows/s | 178 MB (±178) | 34.54s | 178 MB |
 
 #### What changed since v1.x
 
-- **S3 throughput is up roughly 2–3×** for any workload above 50K rows
-  (1M: 95K rows/s vs 43K, 4.5M: 107K rows/s vs 46K). Most of the win
-  comes from updated `aws/aws-sdk-php` (3.379+) and a faster network on
-  the measurement machine — the multipart-upload code path itself is
-  unchanged.
-- **Local throughput is ~5–10% lower** than the v1.x numbers — the cost
-  of the v2.0+ per-cell type detection (boolean cells, `DateTimeInterface`
-  → serial date, big-integer-string preservation). It's a deliberate
-  trade-off: v1.x produced silently broken cells for those types.
+- **Local throughput is now ~15–25% *faster* than the v1.x baseline**
+  (1M rows: 210K rows/s vs 183K). The v2.0+ per-cell type detection
+  added a small overhead at first (v2.0 was about 5% slower than v1.x),
+  but v2.2.2 fixed a long-standing bug in the XML escape fast path — the
+  `strpbrk` needle was a single-quoted literal so `\xNN` escapes were
+  embedded as the characters `\`, `x`, `0..9`, `A..F` instead of as
+  actual control bytes. The fix shrank the needle from 129 to 36 chars
+  and per-cell sanitization got ~3.5× cheaper as a side effect.
+- **S3 throughput is up 2.5–3× over v1.x** for any workload above 50K
+  rows (1M: 107K rows/s vs 43K, 4.5M: 130K rows/s vs 46K). Drivers:
+  AWS SDK 3.379+, faster measurement-machine network, and a smaller
+  share from the per-row hot-path improvement.
 - **Memory is unchanged** — local stays at 0–2 MB constant, S3 keeps the
   same sawtooth pattern as the buffer fills and flushes per part.
 
@@ -122,10 +125,10 @@ The ± values in S3 memory represent **normal memory fluctuation** during stream
    - Pattern: Memory oscillates between ~2MB (after upload) and ~78MB (before upload)
    - This is **completely normal** and expected behavior
 
-### Performance Highlights *(v2.2, May 2026)*
+### Performance Highlights *(v2.2.2, May 2026)*
 
-- **Local File System**: ~160,000–175,000 rows/second with true O(1) memory
-- **S3 Streaming**: 90,000–110,000 rows/second above 1M rows (2–3× the v1.x baseline)
+- **Local File System**: ~190,000–215,000 rows/second with true O(1) memory
+- **S3 Streaming**: 105,000–130,000 rows/second above 1M rows (2.5–3× the v1.x baseline)
 - **Memory Efficiency**: Local uses <2 MB, S3 averages 40 MB per million rows
 - **Multi-sheet Support**: Automatic sheet creation at Excel's 1,048,576 row limit
 - **Production Ready**: Successfully tested with 4.5 million rows
@@ -137,8 +140,8 @@ The ± values in S3 memory represent **normal memory fluctuation** during stream
 | PHPSpreadsheet | ❌ Crashes | ~8GB | Full file | Indirect |
 | Spout | ~60 sec | ~100MB+ | Full file | Indirect |
 | Laravel Excel | ~90 sec | ~500MB+ | Full file | Indirect |
-| **Kolay XLSX Stream (Local)** | ✅ **6.2 sec** | ✅ **0 MB** | ✅ **Zero** | N/A |
-| **Kolay XLSX Stream (S3)** | ✅ **10.5 sec** | ✅ **40MB avg** | ✅ **Zero** | ✅ **Direct** |
+| **Kolay XLSX Stream (Local)** | ✅ **4.8 sec** | ✅ **0 MB** | ✅ **Zero** | N/A |
+| **Kolay XLSX Stream (S3)** | ✅ **9.4 sec** | ✅ **40MB avg** | ✅ **Zero** | ✅ **Direct** |
 
 ## Requirements
 
@@ -409,6 +412,13 @@ $writer->startFile($headers);
 $writer->writeRows($query->lazy());
 $writer->finishFile();
 ```
+
+> **Note on `$bytes`** — the byte counter only advances when zlib emits
+> compressed output. With small datasets (or when `setBufferFlushInterval()`
+> is large relative to `setProgressInterval()`), several events in a row
+> may report the same byte count between flushes. The row counter is always
+> exact; if you need accurate streamed-byte progress on small files, lower
+> `setBufferFlushInterval()` below your progress interval.
 
 ### Supported Cell Data Types
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ listed below `Backlog` is "considered, not committed".
 
 | Version | Date | Highlights |
 |---|---|---|
+| [2.2.2](CHANGELOG.md#222--2026-05-03) | 2026-05-03 | XML control-byte sanitization fast-path bug fix (long-standing, pre-v2.x); `onProgress` byte-counter doc note |
 | [2.2.1](CHANGELOG.md#221--2026-05-03) | 2026-05-03 | Hex color validation, custom font name, empty-workbook guard, deferred column-format check, wider integer/decimal auto-width minimums, micro-perf tightenings |
 | [2.2.0](CHANGELOG.md#220--2026-05-03) | 2026-05-03 | Header styling, column number formats, freeze pane, auto-filter, manual + format-aware auto column widths, manual `newSheet()` |
 | [2.1.0](CHANGELOG.md#210--2026-05-03) | 2026-05-03 | `forDisk()` Laravel Storage integration, `onProgress()` callback, `writeRows(iterable)` Generator support |

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -928,7 +928,13 @@ abstract class BaseXlsxWriter
             "'" => '&apos;',
         ];
 
-        if (strpbrk($str, '&<>"\'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F') === false) {
+        // Double-quoted needle so \xNN escape sequences resolve to the
+        // actual control bytes (0x00..0x1F minus \t \n \r). The previous
+        // single-quoted form embedded the literal characters \, x, 0..9,
+        // A..F instead, which let pure-lowercase strings with embedded
+        // nulls bypass sanitization entirely — Excel rejects the workbook
+        // because XML 1.0 forbids those bytes.
+        if (strpbrk($str, "&<>\"'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F") === false) {
             return $str;
         }
 

--- a/tests/XmlSanitizationTest.php
+++ b/tests/XmlSanitizationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests;
+
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+use ZipArchive;
+
+/**
+ * Regression coverage for the v2.2.2 control-byte fast-path bug.
+ *
+ * Pre-fix, the strpbrk needle was a single-quoted string literal so
+ * "\x00" landed as the four characters "\", "x", "0", "0" instead of a
+ * real null byte. Inputs whose characters didn't overlap with
+ * "&<>\"'\\x0..9A..F" sailed past sanitization and Excel rejected the
+ * resulting workbook with "Char 0x0 out of allowed range".
+ */
+class XmlSanitizationTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/sanitize_'.uniqid().'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+        parent::tearDown();
+    }
+
+    public function test_pure_lowercase_with_control_byte_is_stripped()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['Dirty']);
+        $writer->writeRow(["abc\x00def"]);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertNoControlBytes($xml);
+        $this->assertStrictXmlParses($xml);
+    }
+
+    public function test_pure_control_bytes_are_stripped()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['Dirty']);
+        $writer->writeRow(["\x00\x01\x02\x03\x04\x05\x06\x07\x08"]);
+        $writer->writeRow(["\x0B\x0C\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"]);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertNoControlBytes($xml);
+        $this->assertStrictXmlParses($xml);
+    }
+
+    public function test_mixed_case_with_control_bytes_strict_parses()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['Mixed']);
+        $writer->writeRow(["lowercase\x00MIXED"]);
+        $writer->writeRow(["UPPER\x07lower"]);
+        $writer->writeRow(["data\x01with\x02breaks"]);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertNoControlBytes($xml);
+        $this->assertStrictXmlParses($xml);
+    }
+
+    public function test_control_bytes_in_header_are_stripped()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(["Bad\x00Header"]);
+        $writer->writeRow(['ok']);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertNoControlBytes($xml);
+        $this->assertStrictXmlParses($xml);
+    }
+
+    public function test_tab_newline_carriage_return_are_preserved()
+    {
+        // \t (0x09), \n (0x0A), \r (0x0D) are valid XML chars and should
+        // pass through unchanged — we only strip the C0 control set
+        // *minus* those three.
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['Whitespace']);
+        $writer->writeRow(["line1\nline2"]);
+        $writer->writeRow(["before\ttab"]);
+        $writer->writeRow(["cr\rhere"]);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStrictXmlParses($xml);
+        $this->assertStringContainsString("line1\nline2", $xml);
+        $this->assertStringContainsString("before\ttab", $xml);
+    }
+
+    public function test_special_xml_chars_still_escaped()
+    {
+        // Sanity: the slow path still escapes &<>"' correctly.
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['Special']);
+        $writer->writeRow(['<tag>&"\'']);
+        $writer->finishFile();
+
+        $xml = $this->extract('xl/worksheets/sheet1.xml');
+        $this->assertStringContainsString('&lt;tag&gt;&amp;&quot;&apos;', $xml);
+        $this->assertStrictXmlParses($xml);
+    }
+
+    private function assertNoControlBytes(string $xml): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\x00-\x08\x0B\x0C\x0E-\x1F]/',
+            $xml,
+            'Output contains forbidden XML 1.0 control bytes'
+        );
+    }
+
+    private function assertStrictXmlParses(string $xml): void
+    {
+        libxml_use_internal_errors(true);
+        libxml_clear_errors();
+        $parsed = simplexml_load_string($xml);
+        $errors = array_map(fn ($e) => trim($e->message), libxml_get_errors());
+        libxml_clear_errors();
+
+        $this->assertNotFalse(
+            $parsed,
+            'libxml strict parse failed: '.implode(' | ', $errors)
+        );
+    }
+
+    private function extract(string $entry): string
+    {
+        $zip = new ZipArchive();
+        $zip->open($this->testFile);
+        $content = $zip->getFromName($entry);
+        $zip->close();
+
+        return $content;
+    }
+}


### PR DESCRIPTION
Patch release fixing a pre-existing v1.x bug surfaced by external review on top of v2.2.1. The fix happens to come with a substantial throughput win.

## The bug

`fastXmlEscape` used a single-quoted PHP string literal as the strpbrk needle:

```php
strpbrk(\$str, '&<>\"\\'\\x00\\x01\\x02...')
```

PHP single-quoted strings don't interpret \`\\xNN\` escapes, so the needle was the **literal characters** \`\\\`, \`x\`, \`0\`, \`1\`, ..., \`F\`. Inputs whose characters didn't overlap with that ASCII set bypassed sanitization entirely.

**Reproducer:**

```php
\$writer->writeRow([\"abc\\x00def\"]);  // pure lowercase + null byte
// libxml: \"Char 0x0 out of allowed range\" — Excel rejects the workbook
```

Real-world trigger: dirty user-generated content (mobile keyboard zero-width chars, copy-paste artefacts, database leftovers) in pure-lowercase Latin or multi-byte UTF-8 columns.

## The fix

Single character — switch the needle to a double-quoted string so the escapes resolve.

## Side effect: substantial perf win

The buggy needle was 129 chars (5 + 31x4 literal pairs). The corrected needle is 36 chars (5 + 31 actual control bytes). `strpbrk` per-input-char comparison is ~3.5x cheaper.

Comprehensive benchmark on the same machine and workload as the v2.2 README table:

| Workload | v2.2 README | v2.2.2 | Diff |
|---|---|---|---|
| 1M rows local | 161K rows/s | **210K rows/s** | **+30%** |
| 1M rows S3 | 95K rows/s | **107K rows/s** | +12% |
| 2M rows local | 166K rows/s | 209K rows/s | +25% |
| 4.5M rows S3 | 107K rows/s | **130K rows/s** | +22% |

We also passed the v1.x baseline (Sept 2025) — local 1M was 183K rows/s in v1.x, now **210K rows/s** in v2.2.2 (+15%). The \"v2.x type detection costs ~5-10% locally\" trade-off documented in v2.2.0 is no longer true.

Memory is unchanged (local 0-2 MB constant, S3 sawtooth pattern intact).

## Tests

89 / 183 assertions, all green. New \`tests/XmlSanitizationTest.php\` covers:

- Pure-lowercase string with null byte
- Full C0 control byte set
- Mixed case with embedded controls
- Header sanitization
- Preservation of \`\\t\\n\\r\` (valid XML chars)
- Slow-path \`&<>\"'\` escape sanity
- libxml strict parse on every output (matches Excel's behaviour)

## Documentation

- README's Latest Benchmark table refreshed with v2.2.2 numbers
- Performance Highlights / Comparison rows updated
- \"What changed since v1.x\" notes flipped — local is now ~15-25% **faster** than v1.x, not slower
- New note in onProgress section: \`\$bytes\` only advances when zlib emits, so small datasets may report the same byte count across consecutive events between flushes
