### PR TITLE
feat: per-row styling via writeRow($row, ?int $styleId)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,12 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Laravel test-scaffolding deps (illuminate/support, orchestra/testbench)
+          # pull in laravel/framework, whose full v10–v13 range is currently flagged
+          # by security advisories. Newer Composer blocks advisory-affected installs
+          # by default; these are dev/test-only deps (not shipped), so opt out here.
+          # `|| true` keeps it a no-op on older Composer that lacks the policy key.
+          composer config --no-plugins policy.advisories.block false || true
           composer require \
             "illuminate/support:${{ matrix.laravel }}" \
             "orchestra/testbench:${{ matrix.testbench }}" \
@@ -83,7 +89,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress
+        run: |
+          composer config --no-plugins policy.advisories.block false || true
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
@@ -102,7 +110,9 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress
+        run: |
+          composer config --no-plugins policy.advisories.block false || true
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Check code style
         run: vendor/bin/pint --test

--- a/src/Styles/StyleRegistry.php
+++ b/src/Styles/StyleRegistry.php
@@ -153,6 +153,59 @@ class StyleRegistry
     }
 
     /**
+     * Register a per-row style and return its cellXfs index.
+     *
+     * Structurally identical to a header style — fill (background) + font
+     * (color/bold/size/name) — but exposed separately so the intent reads
+     * clearly at the call site:
+     *
+     *   $red = $writer->registerRowStyle(['fill' => '#FFC7CE', 'color' => '#9C0006']);
+     *   $writer->writeRow($row, $failed ? $red : null);
+     *
+     * Same options → same style id (dedup via resolveCellXf), so painting a
+     * million rows with one logical style still adds a single cellXfs entry.
+     */
+    public function registerRowStyle(array $options): int
+    {
+        return $this->registerHeaderStyle($options);
+    }
+
+    /**
+     * Compose a row style (fill + font) with a column's number format and
+     * return the merged cellXfs index.
+     *
+     * Needed because a styled row must still respect a column's numFmt —
+     * a currency column on a highlighted row should stay "1.234,50 ₺", not
+     * collapse to a raw number. Takes the numFmt from the column xf and the
+     * font/fill from the row xf. Dedup'd, so each (row-style, column) pair
+     * resolves to one entry no matter how many rows hit it.
+     */
+    public function mergeRowStyleWithColumn(int $rowStyleId, int $columnStyleId): int
+    {
+        $row = $this->cellXfs[$rowStyleId] ?? null;
+        $col = $this->cellXfs[$columnStyleId] ?? null;
+
+        // Defensive: an unknown id means the caller passed something we never
+        // handed out. Fall back to whichever side we do know rather than
+        // emitting a dangling s="N".
+        if ($row === null) {
+            return $columnStyleId;
+        }
+        if ($col === null) {
+            return $rowStyleId;
+        }
+
+        return $this->resolveCellXf([
+            'numFmtId' => $col['numFmtId'],
+            'fontId' => $row['fontId'],
+            'fillId' => $row['fillId'],
+            'applyNumberFormat' => $col['applyNumberFormat'],
+            'applyFont' => $row['applyFont'],
+            'applyFill' => $row['applyFill'],
+        ]);
+    }
+
+    /**
      * Reject anything that isn't a 6-character hex color, with or without
      * a leading "#". Surfaces typos at registration time instead of
      * producing a styles.xml Excel will refuse to open.

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -110,6 +110,16 @@ abstract class BaseXlsxWriter
     /** @var array<int, string> 1-based column index => format preset name (used for auto-width sizing) */
     protected array $columnFormatNames = [];
 
+    /**
+     * Memoized merge of a per-row style with a column number format.
+     * Keyed [rowStyleId][columnStyleId] => merged cellXfs id. Keeps the
+     * styled hot path off StyleRegistry's O(n) dedup scan after the first
+     * time a (row-style, column) pair is seen.
+     *
+     * @var array<int, array<int, int>>
+     */
+    protected array $rowStyleMergeCache = [];
+
     // Sheet view options (v2.2+)
     protected int $freezeRows = 0;
     protected int $freezeColumns = 0;
@@ -293,6 +303,38 @@ abstract class BaseXlsxWriter
         $this->headerStyleId = $this->styles->registerHeaderStyle($options);
 
         return $this;
+    }
+
+    /**
+     * Register a reusable per-row style and return its id, to be passed as
+     * the second argument of writeRow().
+     *
+     * Options are identical to setHeaderStyle(): fill (background #RRGGBB),
+     * color (text #RRGGBB), bold, size, name. Register each logical style
+     * once up front, then stamp it on whichever rows you choose:
+     *
+     *   $failed = $writer->registerRowStyle(['fill' => '#FFC7CE', 'color' => '#9C0006']);
+     *   $vip    = $writer->registerRowStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF']);
+     *
+     *   foreach ($rows as $r) {
+     *       $writer->writeRow($r->toArray(), $r->failed ? $failed : null);
+     *   }
+     *
+     * Styles are dedup'd, so one logical style is a single styles.xml entry
+     * no matter how many rows use it — memory stays flat. Passing null (the
+     * writeRow default) keeps a row on the unstyled fast path at zero cost.
+     *
+     * A styled row still honours column number formats: a currency or date
+     * column keeps its format and gains the row's fill/color (the two are
+     * merged on the fly, also dedup'd).
+     */
+    public function registerRowStyle(array $options): int
+    {
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
+        }
+
+        return $this->styles->registerRowStyle($options);
     }
 
     /**
@@ -538,7 +580,7 @@ abstract class BaseXlsxWriter
     /**
      * Write a single row (handles multi-sheet automatically)
      */
-    public function writeRow(array $row): void
+    public function writeRow(array $row, ?int $styleId = null): void
     {
         if (!$this->started) {
             throw XlsxStreamException::headersNotSet();
@@ -563,7 +605,7 @@ abstract class BaseXlsxWriter
         $this->currentSheetRow++;
         $this->totalRows++;
 
-        $rowXml = $this->buildRowXml($this->currentSheetRow, $row);
+        $rowXml = $this->buildRowXml($this->currentSheetRow, $row, $styleId);
 
         // Sample-mode width tracking (opt-in). Buffers row XML + records
         // per-column max char length until the sample size is reached or
@@ -1218,10 +1260,19 @@ abstract class BaseXlsxWriter
     }
 
     /**
-     * Build row XML with optimization
+     * Build row XML with optimization.
+     *
+     * The unstyled path ($rowStyleId === null) is the hot path and is kept
+     * byte-for-byte identical to pre-v3.0.2 — a single null check delegates
+     * the rare styled case to buildStyledRowXml so the common case pays
+     * nothing for the feature.
      */
-    protected function buildRowXml(int $rowIndex, array $data): string
+    protected function buildRowXml(int $rowIndex, array $data, ?int $rowStyleId = null): string
     {
+        if ($rowStyleId !== null) {
+            return $this->buildStyledRowXml($rowIndex, $data, $rowStyleId);
+        }
+
         $cells = [];
         $colIndex = 1;
         // Hoist the styles-empty check so the fast (unstyled) path skips the
@@ -1291,6 +1342,105 @@ abstract class BaseXlsxWriter
         }
 
         return '<row r="' . $rowIndex . '">' . implode('', $cells) . '</row>';
+    }
+
+    /**
+     * Styled-row variant of buildRowXml — stamps $rowStyleId onto every cell
+     * so the whole row carries the fill/font, including empty cells (so the
+     * highlight doesn't show gaps).
+     *
+     * Number formats still win their cell: where a column has its own format,
+     * the row's fill/font is merged with that column's numFmt (memoized in
+     * rowStyleMergeCache) rather than overwriting it. Type detection mirrors
+     * buildRowXml exactly; only the s="N" attribute differs.
+     */
+    protected function buildStyledRowXml(int $rowIndex, array $data, int $rowStyleId): string
+    {
+        $cells = [];
+        $colIndex = 1;
+        $hasColumnStyles = ! empty($this->columnStyleIds);
+        // Hoist the row's style attribute so it's stringified once per row,
+        // not once per cell. Cells that need a merged (column-format) style
+        // build their own; everything else reuses this.
+        $sAttr = ' s="' . $rowStyleId . '"';
+
+        foreach ($data as $value) {
+            $cellRef = $this->getColumnLetter($colIndex) . $rowIndex;
+            $col = $colIndex;
+            $colIndex++;
+
+            // Null / empty string -> empty but still filled cell
+            if ($value === null || $value === '') {
+                $cells[] = '<c r="' . $cellRef . '"' . $sAttr . '/>';
+                continue;
+            }
+
+            // Boolean -> native Excel boolean cell
+            if (is_bool($value)) {
+                $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="b"><v>' . ($value ? 1 : 0) . '</v></c>';
+                continue;
+            }
+
+            // DateTimeInterface -> Excel serial date; merge row style with the
+            // column's date format (or the legacy datetime style as fallback).
+            if ($value instanceof \DateTimeInterface) {
+                $serial = ($value->getTimestamp() - self::EXCEL_EPOCH_TIMESTAMP) / 86400;
+                $columnStyleId = $hasColumnStyles && isset($this->columnStyleIds[$col])
+                    ? $this->columnStyleIds[$col]
+                    : self::STYLE_DATETIME;
+                $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $columnStyleId);
+                $cells[] = '<c r="' . $cellRef . '" s="' . $styleId . '" t="n"><v>' . $serial . '</v></c>';
+                continue;
+            }
+
+            // Numeric values
+            if (is_int($value) || is_float($value)) {
+                if ($hasColumnStyles && isset($this->columnStyleIds[$col])) {
+                    $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $this->columnStyleIds[$col]);
+                    $cells[] = '<c r="' . $cellRef . '" s="' . $styleId . '" t="n"><v>' . $value . '</v></c>';
+                } else {
+                    $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="n"><v>' . $value . '</v></c>';
+                }
+                continue;
+            }
+
+            // Numeric strings: preserve as string when precision/format would be lost
+            if (is_string($value) && is_numeric($value)) {
+                if ($this->shouldPreserveNumericString($value)) {
+                    $escaped = $this->fastXmlEscape($value);
+                    $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+                } elseif ($hasColumnStyles && isset($this->columnStyleIds[$col])) {
+                    $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $this->columnStyleIds[$col]);
+                    $cells[] = '<c r="' . $cellRef . '" s="' . $styleId . '" t="n"><v>' . (0 + $value) . '</v></c>';
+                } else {
+                    $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="n"><v>' . (0 + $value) . '</v></c>';
+                }
+                continue;
+            }
+
+            // String / Stringable / other -> inlineStr
+            $escaped = $this->fastXmlEscape((string)$value);
+
+            if ($escaped !== '' && ($escaped[0] === ' ' || $escaped[0] === "\t" ||
+                $escaped[strlen($escaped) - 1] === ' ' || $escaped[strlen($escaped) - 1] === "\t")) {
+                $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
+            } else {
+                $cells[] = '<c r="' . $cellRef . '"' . $sAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+            }
+        }
+
+        return '<row r="' . $rowIndex . '">' . implode('', $cells) . '</row>';
+    }
+
+    /**
+     * Memoized wrapper over StyleRegistry::mergeRowStyleWithColumn so a
+     * (row-style, column-style) pair only hits the registry's dedup scan
+     * once, not on every styled cell.
+     */
+    protected function mergeRowStyleWithColumnStyle(int $rowStyleId, int $columnStyleId): int
+    {
+        return $this->rowStyleMergeCache[$rowStyleId][$columnStyleId]
+            ??= $this->styles->mergeRowStyleWithColumn($rowStyleId, $columnStyleId);
     }
 
     /**

--- a/tests/Writers/V302RowStyleTest.php
+++ b/tests/Writers/V302RowStyleTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+use ZipArchive;
+
+/**
+ * v3.0.2 — per-row styling via writeRow($row, $styleId).
+ */
+class V302RowStyleTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/v302_'.uniqid().'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testFile)) {
+            unlink($this->testFile);
+        }
+        parent::tearDown();
+    }
+
+    private function extract(string $entry): string
+    {
+        $zip = new ZipArchive();
+        $zip->open($this->testFile);
+        $content = $zip->getFromName($entry);
+        $zip->close();
+
+        return $content;
+    }
+
+    public function test_row_style_stamps_every_cell_in_the_row()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $red = $writer->registerRowStyle(['fill' => '#FFC7CE', 'color' => '#9C0006']);
+        $writer->startFile(['ID', 'Name', 'Status']);
+        $writer->writeRow([1, 'Alice', 'OK']);            // unstyled
+        $writer->writeRow([2, 'Bob', 'FAILED'], $red);    // styled
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $styles = $this->extract('xl/styles.xml');
+
+        // The styled fill + font color land in styles.xml
+        $this->assertStringContainsString('rgb="FFFFC7CE"', $styles);
+        $this->assertStringContainsString('rgb="FF9C0006"', $styles);
+
+        // Header is row 1; data rows follow. Row 3 is the styled "FAILED" row.
+        preg_match('#<row r="3">(.*?)</row>#', $sheet, $m);
+        $this->assertNotEmpty($m, 'row 3 not found');
+        $this->assertSame(3, substr_count($m[1], '<c '), 'expected 3 cells in styled row');
+        $this->assertSame(3, substr_count($m[1], ' s="'), 'every cell in styled row must carry s=');
+
+        // Row 2 (unstyled data) must NOT carry any style attribute — fast path intact
+        preg_match('#<row r="2">(.*?)</row>#', $sheet, $m1);
+        $this->assertStringNotContainsString(' s="', $m1[1]);
+    }
+
+    public function test_null_passes_through_to_unstyled_fast_path()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->registerRowStyle(['fill' => '#FFC7CE']); // registered but not applied
+        $writer->startFile(['A', 'B']);
+        $writer->writeRow(['x', 'y']);          // implicit null style
+        $writer->writeRow(['z', 'w'], null);    // explicit null style
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // Header is row 1; data rows are rows 2 and 3. Neither may carry a style id.
+        $this->assertStringNotContainsString('<c r="A2" s="', $sheet);
+        $this->assertStringNotContainsString('<c r="A3" s="', $sheet);
+    }
+
+    public function test_empty_cells_in_styled_row_are_still_filled()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $blue = $writer->registerRowStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF']);
+        $writer->startFile(['A', 'B', 'C']);
+        $writer->writeRow(['x', null, 'z'], $blue);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        // Header is row 1; the styled row is row 2. The empty B2 cell still
+        // carries the style so the highlight is contiguous.
+        $this->assertMatchesRegularExpression('#<c r="B2" s="\d+"/>#', $sheet);
+    }
+
+    public function test_dedup_one_style_for_many_styled_rows()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $red = $writer->registerRowStyle(['fill' => '#FFC7CE']);
+        $writer->startFile(['A']);
+        for ($i = 0; $i < 1000; $i++) {
+            $writer->writeRow([$i], $red);
+        }
+        $writer->finishFile();
+
+        $styles = $this->extract('xl/styles.xml');
+        // The fill color appears exactly once despite 1000 styled rows.
+        $this->assertSame(1, substr_count($styles, 'rgb="FFFFC7CE"'));
+    }
+
+    public function test_row_style_merges_with_column_number_format()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setColumnFormat(2, 'currency_try');
+        $red = $writer->registerRowStyle(['fill' => '#FFC7CE']);
+        $writer->startFile(['Name', 'Amount']);
+        $writer->writeRow(['Alice', 1234.5], $red);
+        $writer->finishFile();
+
+        $sheet = $this->extract('xl/worksheets/sheet1.xml');
+        $styles = $this->extract('xl/styles.xml');
+
+        // The currency format code survives.
+        $this->assertStringContainsString('₺', $styles);
+        // The styled currency cell (B2 — header is row 1) uses a merged xf
+        // (fill + numFmt), not the bare currency style nor a fill-only style —
+        // i.e. a cellXf with BOTH a custom numFmtId and the fill's fontId/fillId.
+        preg_match('#<c r="B2" s="(\d+)" t="n">#', $sheet, $m);
+        $this->assertNotEmpty($m, 'B2 styled numeric cell not found');
+
+        // The merged xf must apply both number format and fill.
+        $mergedId = (int) $m[1];
+        preg_match_all('#<xf [^>]*/>#', $styles, $xfs);
+        $this->assertArrayHasKey($mergedId, $xfs[0], 'merged xf index out of range');
+        $mergedXf = $xfs[0][$mergedId];
+        $this->assertStringContainsString('applyNumberFormat="1"', $mergedXf);
+        $this->assertStringContainsString('applyFill="1"', $mergedXf);
+    }
+
+    public function test_styled_file_is_valid_zip_and_opens()
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $ok = $writer->registerRowStyle(['fill' => '#C6EFCE', 'color' => '#006100']);
+        $bad = $writer->registerRowStyle(['fill' => '#FFC7CE', 'color' => '#9C0006', 'bold' => true]);
+        $writer->startFile(['ID', 'When', 'Amount', 'Status']);
+        $writer->writeRow([1, new \DateTimeImmutable('2024-01-01 10:00:00'), 99.9, 'OK'], $ok);
+        $writer->writeRow([2, new \DateTimeImmutable('2024-02-01 11:00:00'), 1.5, 'FAILED'], $bad);
+        $writer->writeRow([3, new \DateTimeImmutable('2024-03-01 12:00:00'), 7.0, 'OK']);
+        $stats = $writer->finishFile();
+
+        $this->assertSame(3, $stats['rows']);
+
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($this->testFile) === true, 'output is not a valid zip');
+        $this->assertNotFalse($zip->getFromName('xl/worksheets/sheet1.xml'));
+        $zip->close();
+    }
+}


### PR DESCRIPTION
Add opt-in per-row fill/font styling so callers can highlight selected rows (e.g. failed rows in red, VIP rows in blue), including both background fill and text color on any chosen row.

API
---
- registerRowStyle(array $options): int Registers a reusable row style (fill/color/bold/size/name, using the same options as setHeaderStyle) and returns a stable, deduplicated style ID.

- writeRow(array $row, ?int $styleId = null) Adds an optional second argument for applying a registered row style. Passing null (the default) keeps the existing fast path completely unchanged.

Implementation
--------------
- The unstyled hot path remains byte-for-byte identical. A single null check in buildRowXml() delegates styled rows to buildStyledRowXml(), ensuring existing exports incur effectively zero overhead.

- Row styles are deduplicated through StyleRegistry. Each logical style is stored only once in cellXfs regardless of how many rows use it, keeping memory usage flat even when styling millions of rows.

- Styled rows continue to respect column number formats. Currency, date, and other formatted columns retain their formatting while inheriting the row's fill and font color through an on-the-fly merged cellXf created by mergeRowStyleWithColumn(). These merged styles are memoized per (rowStyle, column) combination.

- Empty cells within a styled row are still emitted so that background highlighting remains visually continuous across the entire row.

- The row style lookup is hoisted outside the per-cell loop, keeping the performance overhead of selectively styled rows effectively negligible.

Compatibility
-------------
- The reader is unchanged. It remains value-only and continues to ignore the s="N" style attribute, just as it already does for header styles and column formatting.

## What

A brief description of the change. One or two sentences.

## Why

What problem does this solve? Link to the issue if there is one.

If there's no issue, explain the use case — non-trivial PRs without
prior discussion may be closed with a request to open an issue first
(see CONTRIBUTING.md).

## How

Key implementation decisions. Anything reviewers should look out for —
tradeoffs, alternatives considered, areas you're uncertain about.

## Tests

- [ ] Added tests covering the new behavior
- [ ] All existing tests pass locally (`composer test`)
- [ ] Tested with a real XLSX output opened in Excel / LibreOffice
      (for changes affecting cell rendering, styling, or schema)

## Performance impact

For changes touching the hot path (`writeRow`, sanitization, ZIP/XML
generation, S3 multipart):

- [ ] Ran `php benchmark-comprehensive.php` before and after
- [ ] Memory profile unchanged or improved
- Before: <!-- e.g. 192K rows/s, 2MB peak -->
- After:  <!-- e.g. 195K rows/s, 2MB peak -->

If this PR doesn't touch the hot path, delete this section.

## Checklist

- [ ] CHANGELOG.md updated under `[Unreleased]`
- [ ] No backwards-incompatible changes (or UPGRADE.md updated)
- [ ] Public API additions have at least one test
- [ ] Documentation updated if behavior or signatures changed
- [ ] Code follows PSR-12 and existing patterns in the codebase

## Screenshots / Output

If your change affects XLSX output (styling, formatting, layout),
attach a screenshot of the resulting file opened in Excel.

## Related

- Issue: #
- Discussion: #
- Related PRs: #
