### PR TITLE
V3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.2.2] — 2026-07-05
 
-Correctness patch. No new public API. The writer's output path is
-untouched — the only writer change is constructor-time config-defaults
-wiring (below); the bytes it produces are the 3.2.1 bytes, and the
-single-sheet read path measures within ±1 % of 3.2.1 (A/B, five-run
-medians) — the auto-split fix costs nothing unless a file actually has
-a continuation chain.
+Correctness patch. No new public API. Row/cell bytes are unchanged
+(pinned by test — every `s=` style id and cell body is byte-identical
+to 3.2.1); the writer changes are constructor-time config wiring and
+two `<cols>`/preamble metadata fixes, all below. The single-sheet read
+path measures within ±1 % of 3.2.1 (A/B, five-run medians) — the
+auto-split fix costs nothing unless a file actually has a continuation
+chain.
 
 ### Fixed — auto-split workbooks now answer queries for the WHOLE table
 
@@ -56,6 +57,34 @@ continuation chain:
   `onSheet()`/`onSheetIndex()` still answers for the whole chain — a
   physical continuation sheet is not a meaningful query target. Sheets
   outside the chain are unaffected.
+
+### Fixed — sample-mode auto width: config mutations no longer act retroactively
+
+With sample-based auto column width (`setAutoColumnWidth(N)`), the
+active sheet's preamble is deferred until the sample finalizes. Config
+mutations issued while a sample was pending — the natural
+"prepare-the-next-sheet, then `newSheet()`" sequence — leaked backwards
+into that deferred preamble: `clearColumnFormats()` erased the pending
+sheet's explicit `setColumnWidths()` entries (a user width of 40 lost
+to a sampled 131), and `setHeaderStyle()` repainted the pending sheet's
+header with the NEXT sheet's style. Reordering didn't help: calling
+`clearColumnFormats()` after `newSheet()` instead tripped the
+format-vs-header-count validation. The rule is now enforced in one
+place: **a config mutation never acts retroactively** — mutators that
+feed the preamble (`setHeaderStyle`, `setColumnFormat`,
+`clearColumnFormats`, `setColumnWidths`, `setAutoColumnWidth`, freeze
+panes) finalize a pending sample first, with the state it was sampled
+under. Found by a real-Excel manual test; regression-tested red→green.
+
+### Fixed — builtin numFmt ids now get sensible minimum column widths
+
+Heuristic auto width (`setAutoColumnWidth(true)`) knew format-aware
+minimum widths only for named format presets; columns formatted with
+the `BUILTIN_NUMFMT_*` id constants (date, datetime, currency, …) fell
+back to width 8 and rendered as `#######` in Excel. All thirteen
+builtin ids now map to the same minimums their named counterparts use
+(date 12, datetime 20, currency 14, …). Cell bytes are untouched —
+this only changes the `<cols>` width hints of heuristic-width files.
 
 ### Fixed — the published config now actually applies (versioned)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to `kolay/xlsx-stream` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] — 2026-07-05
+
+Correctness patch. No new public API. The writer's output path is
+untouched — the only writer change is constructor-time config-defaults
+wiring (below); the bytes it produces are the 3.2.1 bytes, and the
+single-sheet read path measures within ±1 % of 3.2.1 (A/B, five-run
+medians) — the auto-split fix costs nothing unless a file actually has
+a continuation chain.
+
+### Fixed — auto-split workbooks now answer queries for the WHOLE table
+
+When an export exceeds Excel's 1,048,576-row sheet ceiling the writer
+auto-splits it across continuation sheets. Every query API silently
+answered from the active sheet alone: on a 2.1M-row file `rowCount()`
+reported 1,048,575, `findRow()` returned null for anything past the
+first sheet, and `columnStats()` summed less than half the data —
+silently. This release makes the whole query surface span the
+continuation chain:
+
+- **Spanned APIs:** `rowCount()`, `rows()`/`chunked()` (including the
+  `skip` fast path), `rowAt()`, `rowRange()`, `rowsWhere()`,
+  `findRow()`, `columnStats()`, `groupStats()`, `quantile()`/
+  `median()`, `countDistinct()`, `shards()`.
+- **Chain detection is deliberately conservative:** consecutive sheets
+  chain only when every non-final member is exactly full (1,048,575
+  rows — the writer's split point, a count no hand-built sheet hits by
+  accident) AND every member carries an identical header row, AND the
+  file is born-indexed (the sidecar provides the O(1) totals the
+  detection needs). Intentional multi-sheet workbooks — different
+  headers, or same-schema sheets that aren't full — keep their
+  per-sheet semantics exactly as before. Single-sheet files take a
+  `count($sheets) < 2` early-out; nothing changes for them.
+- **Global row numbering:** a chain is ONE logical table. Continuation
+  members' repeated header rows do not exist logically; data row *i*
+  lives at global row *i + 1*. `rowsWhere()`/`findRow()`/`rowRange()`
+  keys, `rowAt()` addressing and `rows(skip:)` all use this numbering.
+- **Aggregates compose exactly:** `columnStats()` folds each member's
+  block stats; `quantile()`/`countDistinct()` merge the members'
+  t-digest/HLL sketches (that merge-associativity is why the sidecar
+  stores them per sheet). All-or-nothing rule: if any chain member
+  lacks the column's stats or sketch, the answer is `null` rather than
+  a silent partial — the exact failure mode this release removes.
+- **`shards()`** now fans out over every chain sheet (previously a
+  4M-row file dispatched workers for only its first sheet).
+  `rowsForShard()` keys remain LOCAL to the shard's sheet, as
+  documented — the "skip `$rn === 1`" guidance now applies per member,
+  since each member's first shard carries its (repeated) header.
+- Behaviour note: selecting a chain member explicitly via
+  `onSheet()`/`onSheetIndex()` still answers for the whole chain — a
+  physical continuation sheet is not a meaningful query target. Sheets
+  outside the chain are unaffected.
+
+### Fixed — the published config now actually applies (versioned)
+
+`config/xlsx-stream.php` shipped `writer` / `s3` / `memory` / `logging`
+keys (e.g. `XLSX_STREAM_COMPRESSION_LEVEL`) that no code ever read —
+settings silently did nothing. As of 3.2.2 the config is wired in, with
+two safety properties:
+
+- **Version gate:** the package applies the config only when it carries
+  `'version' => 2` (present in the new published file). Copies
+  published before 3.2.2 lack the key and stay inert — exactly their
+  previous behaviour — because their stale defaults contradict the code
+  (old file said compression level 1; the writer's real default has
+  been 5 since v3.1) and honouring them would have silently changed
+  output for existing installs. Re-publish with
+  `php artisan vendor:publish --tag=xlsx-stream-config --force` to opt
+  in.
+- **Precedence:** code-level setters always override config values,
+  which override package defaults. Invalid config values are ignored
+  (environment data must not turn every `new Writer` into a 500);
+  setters keep throwing on invalid input as before.
+
+Applied keys map 1:1 to real knobs: `writer.compression_level`,
+`writer.buffer_flush_interval`, `s3.part_size` and `s3.concurrency`
+(the `forDisk()` defaults). The old `memory` / `logging` /
+`max_rows_per_sheet` keys had no implementation behind them and are
+gone — a config key that silently does nothing is the exact bug this
+release fixes. Two of the old keys have real homes elsewhere,
+documented in the config file: transient S3 retries belong to the AWS
+SDK's retry middleware (`'retries' => N` on your `S3Client`; the sink
+adds one last-resort re-dispatch), and "logging" is the `onProgress()`
+callback. Outside Laravel nothing changes (`config()` absence is
+guarded).
+
 ## [3.2.1] — 2026-07-04
 
 Documentation-only patch. The v3.2.0 tag was published with this

--- a/README.md
+++ b/README.md
@@ -451,6 +451,16 @@ foreach ($reader->rowRange(100_000, 100_500) as $rowNumber => $row) {
 fall back to a sequential O(N) scan from the first row. Only the cost
 differs; the API contract is identical.
 
+> **The physics of deflate streaming** — seekability requires
+> `Z_FULL_FLUSH` markers, and each marker resets the compressor's
+> dictionary, which in principle costs compression ratio. In practice
+> the cost is negligible at our default cadence: a sync point every
+> 10K rows resets a 32 KB window once per ~1 MB of XML, measured at
+> **+0.04 %** file size on the 500K-row benchmark workload (predicted
+> ceiling ≤0.5 %). You would only notice dictionary-reset overhead at
+> extreme settings like `every: 100` — if you shrink the period for
+> query granularity, re-measure your file sizes.
+
 > **Performance tip:** When you need many adjacent rows, prefer
 > `rowRange($from, $to)` over a loop of `rowAt()` calls. `rowRange()`
 > seeks once and reuses a single inflate stream; repeated `rowAt()`
@@ -850,6 +860,23 @@ $stats = $writer->finishFile();
 // $stats['sheets'] = 2
 ```
 
+**Reading auto-split files back** *(v3.2.2+)*: on born-indexed files the
+reader detects the continuation chain (consecutive exactly-full sheets
+with identical headers) and treats it as ONE logical table — `rowCount()`,
+`rowsWhere()`, `findRow()`, `columnStats()`, `quantile()`, `shards()` and
+friends span every continuation sheet with continuous global row numbers.
+Intentional multi-sheet workbooks (different headers, or sheets that
+aren't exactly full) keep per-sheet semantics. Before v3.2.2 queries
+silently answered from the active sheet alone — treat that as a reason
+to upgrade if you export past one sheet.
+
+Measured on a 2.1M-row, 3-sheet chain (local disk, 6 MB peak RAM):
+chain detection + `rowCount()` 1.5 ms on first call (~1 µs warmed),
+`findRow()` into the second sheet 9.5 ms, `rowAt()` 2.2 ms,
+`columnStats()` 1.5 ms, `quantile()` 1.7 ms. Single-sheet files take an
+early-out before any chain logic — the A/B benchmark against v3.2.1
+shows every single-sheet read path within ±1 % (measurement noise).
+
 ### Performance Tuning
 
 ```php
@@ -858,7 +885,7 @@ $writer->setCompressionLevel(1)        // Minimal compression
        ->setBufferFlushInterval(50000); // Large buffer
 
 // Balanced mode (default)
-$writer->setCompressionLevel(6)        // Balanced compression
+$writer->setCompressionLevel(5)        // Balanced compression (the default)
        ->setBufferFlushInterval(10000); // Medium buffer
 
 // Maximum compression (slower, smaller files)
@@ -908,34 +935,45 @@ try {
 
 ## Configuration
 
-Published configuration file (`config/xlsx-stream.php`):
+Defaults come from the published config file; code-level setters always
+override them at call time. *(Fixed in v3.2.2 — earlier releases
+shipped these keys without reading them; re-publish the config to opt
+in: `php artisan vendor:publish --tag=xlsx-stream-config --force`. The
+new file carries a `'version' => 2` marker; pre-3.2.2 copies stay
+inert so their stale defaults can't silently change your output.)*
 
 ```php
+// config/xlsx-stream.php — applied when 'version' => 2 is present
 return [
-    's3' => [
-        'part_size' => 32 * 1024 * 1024,  // S3 multipart chunk size
-        'retry_attempts' => 3,             // Retry failed uploads
-        'retry_delay_ms' => 100,           // Delay between retries
-    ],
-    
+    'version' => 2,
     'writer' => [
-        'compression_level' => 1,          // 1-9 (1=fastest, 9=smallest)
-        'buffer_flush_interval' => 10000,  // Rows to buffer
-        'max_rows_per_sheet' => 1048575,   // Excel limit - 1
+        'compression_level' => env('XLSX_STREAM_COMPRESSION_LEVEL', 5),
+        'buffer_flush_interval' => env('XLSX_STREAM_BUFFER_FLUSH_INTERVAL', 10000),
     ],
-    
-    'memory' => [
-        'file_buffer_size' => 1024 * 1024, // 1MB file write buffer
-    ],
-    
-    'logging' => [
-        'enabled' => true,
-        'channel' => null,                  // null = default channel
-        'log_progress' => false,            // Log progress updates
-        'progress_interval' => 10000,       // Log every N rows
+    's3' => [
+        'part_size' => env('XLSX_STREAM_S3_PART_SIZE', 8 * 1024 * 1024),
+        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 4),
     ],
 ];
 ```
+
+```php
+// Setters override config per writer instance:
+$writer->setCompressionLevel(9)           // wins over the config value
+       ->setBufferFlushInterval(50000);
+$writer->withRandomAccessIndex(every: 10000)
+       ->withColumnStats([1, 4])
+       ->withColumnSketches([1, 4]);
+$writer->onProgress(fn ($rows, $bytes) => ...)->setProgressInterval(10000);
+
+// Full control: construct the sink directly.
+new S3MultipartSink($s3, $bucket, $key, partSize: 8 * 1024 * 1024, concurrency: 8);
+```
+
+Transient S3 retries belong to the AWS SDK — configure them on your
+`S3Client` (`'retries' => N`); the sink adds one last-resort re-dispatch
+after the SDK gives up. Progress/"logging" is the `onProgress()`
+callback: wire it to your logger of choice.
 
 ## How It Works
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ listed below `Backlog` is "considered, not committed".
 
 | Version | Date | Highlights |
 |---|---|---|
+| [3.2.2](CHANGELOG.md#322--2026-07-05) | 2026-07-05 | Correctness patch: on auto-split workbooks (>1,048,575 rows) the entire query surface — `rowCount`/`rows`/`rowAt`/`rowRange`/`rowsWhere`/`findRow`/`columnStats`/`groupStats`/`quantile`/`countDistinct`/`shards` — now spans the continuation chain as one logical table instead of silently answering from the active sheet alone; misleading never-read config keys removed |
 | [3.2.0](CHANGELOG.md#320--2026-07-04) | 2026-07-04 | KXSI becomes an **open specification** ([SPEC.md](SPEC.md)) with a byte-pinned conformance suite; `SCRC` per-sync-point integrity CRCs; approximate analytics — `withColumnSketches()` embeds t-digest + HyperLogLog, `quantile()`/`median()`/`countDistinct()` answer with zero row reads; `groupStats()` sorted-group pushdown; +30 % read throughput (tokenizer micro-pass); `rows(skip)` fast path (~1,580× indexed) + within-block fast-forward (~19×); parallel S3 multipart upload (flat memory, steady wall times); packed shared strings (ceiling 20 → 64 MB compressed at 3.5× less peak); `autoDetectDates()` for external files |
 | [3.1.0](CHANGELOG.md#310--2026-07-04) | 2026-07-04 | Queryable XLSX: KXSI TLV sidecar extension with per-block column stats (zone maps) — `withColumnStats()` on the writer; `columnStats()`/`rowsWhere()`/`findRow()` on the reader (Parquet-style block pruning, sidecar-only aggregates, single-block point lookups); `shards()`/`rowsForShard()` for zero-coordination queue fan-out; writer +55 % throughput (PCRE-JIT escape gate, flattened row builder, level-5 default); S3 reader open 7 → 3 round trips; `rowCount()` boundary-count fast path |
 | [3.0.0](CHANGELOG.md#300--2026-05-06) | 2026-05-06 | Streaming reader (`StreamingXlsxReader`) with bounded ~24 MB RAM; born-indexed XLSX via opt-in `withRandomAccessIndex()` enabling O(1) `rowAt`/`rowRange`/`rowCount`; external XLSX support via shared-strings; new read + random-access benchmark scripts; tests reorganized under `Writers/` + `Readers/`; no breaking changes |
@@ -37,9 +38,15 @@ concatenation) are already PoC-proven.
   blocks {17, 19, 20}, decide between three requests or one padded
   request from measured RTT/bandwidth (S3 `GetObject` accepts only a
   single range per request).
-- **`explain()`** — return the query plan without executing: strategy,
-  candidate blocks, estimated requests/bytes/latency. Doubles as a CI
+- **`explain()` / `estimatedRows()`** — return the query plan without
+  executing: strategy, candidate blocks, estimated requests/bytes, and
+  a zero-I/O result-size estimate (zone-map counts give a hard upper
+  bound; the t-digest CDF gives a point estimate). Doubles as a CI
   oracle (plan vs. actual request count).
+- **`rowsWhereAll()`** — multi-predicate queries whose per-column
+  zone-map survivor sets are intersected before any block is read
+  (`WHERE date BETWEEN … AND amount > …` scans the intersection, never
+  more blocks than the most selective predicate alone).
 - **Hedged range requests** — re-issue a slow critical-path range on a
   second connection, first response wins; insurance against S3 tail
   latency on point lookups.

--- a/SPEC.md
+++ b/SPEC.md
@@ -20,7 +20,7 @@ OPTIONAL in this document are to be interpreted as described in
 
 | | |
 |---|---|
-| Document version | **1.1.0** |
+| Document version | **1.2.0** |
 | Format version described | KXSI binary version **2** (the `version` header byte) |
 | Reference implementation | `kolay/xlsx-stream` ≥ 3.2.0 (PHP) — writer + reader |
 | Conformance suite | `tests/SpecVectors/` in the reference repository (§8) |
@@ -559,6 +559,52 @@ Failing checks 15–16 SHOULD degrade silently to non-indexed reading
 (the file itself is fine — only the sidecar is unusable); failing
 checks 1–14 indicates a corrupt or crafted sidecar and MAY additionally
 be surfaced as an error.
+
+### 6.1 Continuation chains (informative)
+
+This subsection is **non-normative**: it describes reader behavior the
+reference implementation ships (since v3.2.2), not a property of the
+binary format. It is recorded here so independent implementations can
+reproduce the same query semantics from one description instead of
+reverse-engineering the reference reader.
+
+Writers that split one logical table across multiple worksheets purely
+because of Excel's 1,048,576-row sheet ceiling (the reference writer
+rolls to a new sheet at 1,048,575 rows including the header, and
+re-emits the header row on each continuation sheet) produce what the
+reference reader calls a **continuation chain**. A chain is a maximal
+run of consecutive sheets, in workbook order, where:
+
+1. every non-final member's `total_rows` (from the sidecar) equals
+   exactly **1,048,575** — the reference writer's split point; a
+   hand-authored sheet virtually never lands on this count, which is
+   what makes fullness a reliable continuation signal;
+2. every member's first row (its header) tokenizes to an identical
+   cell sequence; and
+3. the sidecar is present and passes every §6 invariant (the detection
+   consumes `total_rows`, so unindexed files are never chained).
+
+Readers that implement chains treat one chain as ONE logical table:
+
+- **Global row numbering**: the first member contributes rows
+  `1..total_rows`; each continuation member contributes rows
+  `2..total_rows` (its repeated header row does not exist logically),
+  numbered consecutively after the previous member. Data row *i* of
+  the logical table therefore lives at global row *i + 1*.
+- **Aggregates compose**: per-sheet `STAT` blocks fold (min/max/sum/
+  count/other are all associative), and `TDIG`/`CHLL` sketches merge —
+  the merge-associativity documented in §4.3/§4.4 is exactly what
+  makes per-sheet sections chain-composable. Implementations SHOULD be
+  all-or-nothing: if any member lacks a column's section, answer "no
+  data" rather than a silent partial aggregate.
+- Sheets outside the chain (different headers, non-full predecessors)
+  keep per-sheet semantics.
+
+Known false-positive: a hand-built workbook whose sheets are exactly
+1,048,575 rows with identical headers on a born-indexed file is
+indistinguishable from an auto-split chain — and is treated as one.
+Semantically such a file *is* a continuation chain, so the reference
+implementation accepts this deliberately.
 
 ## 7. Security considerations
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,68 @@
 # Upgrade Guide
 
+## Upgrading from v3.2.0 / v3.2.1 to v3.2.2
+
+No breaking API changes — every call site works unchanged. One
+correctness change you should know about, and one opt-in.
+
+### 1. Queries on auto-split workbooks now cover the whole table
+
+If a file was written past Excel's 1,048,576-row sheet ceiling (the
+writer auto-splits it into continuation sheets), the query surface —
+`rowCount()`, `rows()`, `rowAt()`, `rowRange()`, `rowsWhere()`,
+`findRow()`, `columnStats()`, `groupStats()`, `quantile()`/`median()`,
+`countDistinct()`, `shards()` — now answers for the whole continuation
+chain with continuous global row numbers, instead of silently covering
+only the active sheet.
+
+- If you never exceed one sheet, nothing changes (verified within ±1 %
+  of v3.2.1 on every single-sheet read path).
+- Intentional multi-sheet workbooks (`newSheet()` tables with different
+  headers, or same-schema sheets that aren't exactly full) keep their
+  per-sheet semantics.
+- If you had built a workaround that loops `onSheetIndex(...)` over an
+  auto-split file and sums per-sheet answers yourself, remove it —
+  you would now be double-counting: one plain `columnStats()` call is
+  the whole table.
+- `shards()` on an auto-split file now returns shards for every chain
+  sheet (previously only the first). Workers using `rowsForShard()`
+  need no changes — keys stay local to each shard's sheet, and the
+  documented "skip `$rn === 1`" header guidance now simply applies per
+  sheet.
+
+### 2. Opt in to the config file actually working
+
+Published `config/xlsx-stream.php` keys were never read before v3.2.2.
+They now apply at writer construction — but only when the config
+carries `'version' => 2`, so existing published copies stay inert and
+nothing changes until you opt in.
+
+**The safe way to opt in** is re-publishing the file, which ships the
+new defaults (they match the code: compression level 5, flush interval
+10,000, part size 8 MB, concurrency 4):
+
+```bash
+php artisan vendor:publish --tag=xlsx-stream-config --force
+```
+
+Then set the env vars you actually want (`XLSX_STREAM_COMPRESSION_LEVEL`,
+`XLSX_STREAM_BUFFER_FLUSH_INTERVAL`, `XLSX_STREAM_S3_PART_SIZE`,
+`XLSX_STREAM_S3_CONCURRENCY`). Code-level setters always override
+config values.
+
+> **Do NOT just add `'version' => 2` to your old published file.** The
+> pre-3.2.2 file shipped stale defaults that contradict the code —
+> `compression_level => 1` while the writer's real default has been 5
+> since v3.1. Adding the marker to that file as-is would activate
+> level 1 and silently change your output size/speed. Re-publish with
+> `--force` (or review every value first, then add the marker).
+
+Keys that had no implementation behind them are gone from the file:
+`logging.*` (use the `onProgress()` callback), `memory.file_buffer_size`
+and `max_rows_per_sheet` (never configurable). Transient S3 retries are
+configured on your own `S3Client` (`'retries' => N`) — the AWS SDK's
+retry middleware owns them; the sink adds one last-resort re-dispatch.
+
 ## Upgrading from v3.0.x to v3.1
 
 No breaking API changes — every v3.0 call site works unchanged. Two

--- a/config/xlsx-stream.php
+++ b/config/xlsx-stream.php
@@ -1,64 +1,67 @@
 <?php
 
+/*
+|--------------------------------------------------------------------------
+| kolay/xlsx-stream configuration
+|--------------------------------------------------------------------------
+|
+| Precedence: code-level setters > this config > package defaults.
+| Values here are applied when a writer is constructed inside Laravel;
+| any setter you call afterwards (setCompressionLevel(),
+| setBufferFlushInterval(), an explicit $partSize argument) wins.
+| Outside Laravel the file is simply never read.
+|
+| The `version` key is a compatibility gate, not a user setting. Copies
+| of this file published before v3.2.2 listed keys the package never
+| read (writer/s3/memory/logging) with stale values that contradicted
+| the code defaults — e.g. compression_level 1 while the writer's real
+| default is 5. Honouring those old copies retroactively would have
+| silently changed existing applications' output, so the package only
+| applies configs that declare `'version' => 2` (this file). If you
+| still have a pre-3.2.2 copy published, re-publish it:
+|
+|     php artisan vendor:publish --tag=xlsx-stream-config --force
+|
+| Keys with no runtime counterpart (memory.*, logging.*,
+| writer.max_rows_per_sheet) were removed in v3.2.2 and do not come
+| back — the row-per-sheet ceiling is Excel's, not configurable.
+|
+*/
+
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Default S3 Settings
-    |--------------------------------------------------------------------------
-    |
-    | These settings will be used for S3 operations if not specified
-    |
-    */
-    's3' => [
-        'part_size' => env('XLSX_STREAM_S3_PART_SIZE', 32 * 1024 * 1024), // 32MB default
-        'retry_attempts' => env('XLSX_STREAM_S3_RETRY_ATTEMPTS', 3),
-        'retry_delay_ms' => env('XLSX_STREAM_S3_RETRY_DELAY', 100),
-    ],
+    'version' => 2,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Writer Performance Settings
-    |--------------------------------------------------------------------------
-    |
-    | These settings control the performance characteristics of the writer
-    |
-    */
     'writer' => [
-        // Compression level (1-9). 1 = fastest, 9 = best compression
-        'compression_level' => env('XLSX_STREAM_COMPRESSION_LEVEL', 1),
-        
-        // Number of rows to buffer before flushing to output
+        // Deflate level 1-9. 5 is the measured knee of the size/speed
+        // curve for XLSX-shaped XML (within ~0.2% of level 6's size at
+        // ~20% less wall time).
+        'compression_level' => env('XLSX_STREAM_COMPRESSION_LEVEL', 5),
+
+        // Rows buffered before each flush to the sink.
         'buffer_flush_interval' => env('XLSX_STREAM_BUFFER_FLUSH_INTERVAL', 10000),
-        
-        // Maximum rows per sheet (Excel limit is 1,048,576)
-        'max_rows_per_sheet' => env('XLSX_STREAM_MAX_ROWS_PER_SHEET', 1048575),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Memory Settings
-    |--------------------------------------------------------------------------
-    |
-    | Control memory usage of the package
-    |
-    */
-    'memory' => [
-        // File write buffer size
-        'file_buffer_size' => env('XLSX_STREAM_FILE_BUFFER_SIZE', 1024 * 1024), // 1MB
-    ],
+    's3' => [
+        // Multipart part size in bytes for forDisk() writers. S3's
+        // minimum for non-final parts is 5 MB; the sink silently
+        // raises anything smaller.
+        'part_size' => env('XLSX_STREAM_S3_PART_SIZE', 8 * 1024 * 1024),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Logging
-    |--------------------------------------------------------------------------
-    |
-    | Control what gets logged
-    |
-    */
-    'logging' => [
-        'enabled' => env('XLSX_STREAM_LOGGING', true),
-        'channel' => env('XLSX_STREAM_LOG_CHANNEL', null), // null = default channel
-        'log_progress' => env('XLSX_STREAM_LOG_PROGRESS', false), // Log progress updates
-        'progress_interval' => env('XLSX_STREAM_PROGRESS_INTERVAL', 10000), // Log every N rows
+        // Max part uploads in flight at once for forDisk() writers.
+        // Memory ceiling is roughly part_size x (concurrency + 1);
+        // 1 = strictly sequential uploads. Writers that need per-call
+        // control construct S3MultipartSink directly — its constructor
+        // takes both part size and concurrency.
+        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 4),
+
+        // Why there are no retry keys here: transient upload errors are
+        // retried by the AWS SDK's own retry middleware — configure it
+        // on YOUR S3Client ('retries' => N); after the SDK gives up the
+        // sink re-dispatches the part once synchronously as a last
+        // resort. A package-level retry_attempts/retry_delay_ms pair
+        // (as pre-3.2.2 copies listed) would be a dead copy shadowing
+        // the SDK setting, so those keys are intentionally absent.
+        // Likewise the old logging.* keys: the runtime counterpart is
+        // the $writer->onProgress(callable) callback, not a config key.
     ],
 ];

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -5,6 +5,8 @@ namespace Kolay\XlsxStream\Readers;
 use Aws\S3\S3Client;
 use Kolay\XlsxStream\Contracts\Source;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
+use Kolay\XlsxStream\Sketches\HyperLogLog;
+use Kolay\XlsxStream\Sketches\TDigest;
 use Kolay\XlsxStream\Sources\LocalFileSource;
 use Kolay\XlsxStream\Sources\S3RangeSource;
 
@@ -105,6 +107,48 @@ class StreamingXlsxReader
      * @var array<string, list<array{first_row: int, last_row: int, comp_offset: int|null, uncomp_offset: int|null, start_row_at_offset: int|null}>>
      */
     private array $blockRangesByEntry = [];
+
+    /**
+     * Physical row count (header included) of a sheet the writer filled
+     * to Excel's split threshold before rolling to a continuation sheet
+     * (BaseXlsxWriter::ROWS_PER_SHEET). A non-final sheet of an
+     * auto-split chain has EXACTLY this many rows by construction —
+     * that near-impossible-by-hand precision is what makes fullness a
+     * reliable continuation signal.
+     */
+    private const FULL_SHEET_ROWS = 1_048_575;
+
+    /**
+     * Continuation-chain map: entry => ordered members of the chain the
+     * entry belongs to. A chain is a maximal run of consecutive sheets
+     * where every non-final member is exactly full and every member
+     * carries an identical header row — i.e. ONE logical table the
+     * writer split only because of Excel's row ceiling. Populated
+     * lazily by resolveChains(); single-sheet workbooks and files
+     * without a usable sidecar never build it.
+     *
+     * Member shape: entry, total (physical rows incl. header),
+     * dataStartLocal (1 for the first member, 2 for continuations —
+     * their repeated header row does not exist logically), globalStart
+     * (global row number of local row dataStartLocal).
+     *
+     * @var array<string, list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>>|null
+     */
+    private ?array $chainByEntry = null;
+
+    /**
+     * Raw (cast-free) header rows read for chain detection, memoized so
+     * each candidate sheet pays its one small read at most once.
+     *
+     * @var array<string, array<int, mixed>>
+     */
+    private array $headerByEntry = [];
+
+    /** @var array<string, TDigest|null> merged chain digests, keyed chain-head|column */
+    private array $chainDigestCache = [];
+
+    /** @var array<string, HyperLogLog|null> merged chain HLLs, keyed chain-head|column */
+    private array $chainHllCache = [];
 
     /** @var array<int, callable> */
     private array $columnCasts = [];
@@ -271,6 +315,27 @@ class StreamingXlsxReader
             return;
         }
 
+        // Chain: iterate the logical table across every member via the
+        // chain-aware rowRange (casts applied there), re-keying to this
+        // generator's documented 0-based emitted count.
+        $chain = $this->chain();
+        if ($chain !== null) {
+            $globalEnd = $this->chainTotalRows($chain);
+            if ($skip + 1 > $globalEnd) {
+                return;
+            }
+            $emitted = 0;
+            foreach ($this->rowRange($skip + 1, $globalEnd) as $row) {
+                yield $row;
+                $emitted++;
+                if ($limit !== null && $emitted >= $limit) {
+                    return;
+                }
+            }
+
+            return;
+        }
+
         if ($skip > 0) {
             // rows() counts yields, and rowsFromOffset() yields exactly
             // one row per '</row>' boundary from its starting row — so
@@ -340,6 +405,15 @@ class StreamingXlsxReader
      */
     public function rowCount(): int
     {
+        // Auto-split continuation chain: the file is ONE logical table,
+        // so the count spans every member (continuation headers do not
+        // exist logically). Pre-v3.2.2 this silently returned the
+        // active sheet's count alone.
+        $chain = $this->chain();
+        if ($chain !== null) {
+            return $this->chainTotalRows($chain);
+        }
+
         $index = $this->loadRandomAccessIndex();
         if ($index !== null) {
             $total = $index->totalRows($this->currentEntry);
@@ -380,6 +454,32 @@ class StreamingXlsxReader
             return null;
         }
 
+        // Chain: $rowNumber is a GLOBAL row — map it to (member, local)
+        // and read from that member's entry directly. State (casts,
+        // current sheet) is never touched: chain members share one
+        // schema by construction.
+        $chain = $this->chain();
+        if ($chain !== null) {
+            $loc = $this->chainLocate($chain, $rowNumber);
+            if ($loc === null) {
+                return null;
+            }
+            [$memberIdx, $local] = $loc;
+            $entry = $chain[$memberIdx]['entry'];
+            [$compOffset, $startingRow] = $this->seekTarget($local, $entry);
+
+            foreach ($this->openSheetReader([], $entry)->rowsFromOffset($compOffset, $startingRow, $local) as $rn => $row) {
+                if ($rn === $local) {
+                    return $this->applyCasts($row);
+                }
+                if ($rn > $local) {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
         [$compOffset, $startingRow] = $this->seekTarget($rowNumber);
 
         foreach ($this->openSheetReader()->rowsFromOffset($compOffset, $startingRow, $rowNumber) as $rn => $row) {
@@ -408,6 +508,52 @@ class StreamingXlsxReader
             $from = 1;
         }
         if ($to < $from) {
+            return;
+        }
+
+        // Chain: [from, to] are GLOBAL rows — walk the overlapping
+        // members in order, translating each member's local rows back
+        // to global keys. Continuation headers (local row 1) are below
+        // every member's dataStartLocal and never surface.
+        $chain = $this->chain();
+        if ($chain !== null) {
+            $globalEnd = $this->chainTotalRows($chain);
+            if ($from > $globalEnd) {
+                return;
+            }
+            $to = min($to, $globalEnd);
+
+            $loc = $this->chainLocate($chain, $from);
+            if ($loc === null) {
+                return;
+            }
+            [$memberIdx, $localFrom] = $loc;
+
+            for ($i = $memberIdx, $n = count($chain); $i <= $n - 1; $i++) {
+                $m = $chain[$i];
+                $coverEnd = $m['globalStart'] + $m['total'] - $m['dataStartLocal'];
+                if ($m['globalStart'] > $to && $i > $memberIdx) {
+                    return;
+                }
+                $startLocal = $i === $memberIdx ? $localFrom : $m['dataStartLocal'];
+                $stopLocal = $m['dataStartLocal'] + (min($to, $coverEnd) - $m['globalStart']);
+
+                [$compOffset, $startingRow] = $this->seekTarget($startLocal, $m['entry']);
+                foreach ($this->openSheetReader([], $m['entry'])->rowsFromOffset($compOffset, $startingRow, $startLocal) as $rn => $row) {
+                    if ($rn < $startLocal) {
+                        continue;
+                    }
+                    if ($rn > $stopLocal) {
+                        break;
+                    }
+                    yield $m['globalStart'] + ($rn - $m['dataStartLocal']) => $this->applyCasts($row);
+                }
+
+                if ($coverEnd >= $to) {
+                    return;
+                }
+            }
+
             return;
         }
 
@@ -450,6 +596,78 @@ class StreamingXlsxReader
     public function columnStats(int $column): ?array
     {
         $index = $this->loadRandomAccessIndex();
+
+        // Chain: fold every member's blocks — the sidecar carries each
+        // physical sheet's stats separately and sums/min/max compose
+        // exactly. All-or-nothing: if any member lacks the column, the
+        // chain answer would silently cover part of the table (the very
+        // bug this path fixes), so return null instead. `other` keeps
+        // its documented per-physical-sheet header contribution — one
+        // header cell per member for the usual text header.
+        $chain = $this->chain();
+        if ($chain !== null && $index !== null) {
+            $min = null;
+            $max = null;
+            $sum = 0.0;
+            $count = 0;
+            $other = 0;
+            $allAsc = true;
+            $allDesc = true;
+            $prevMemberMin = null;
+            $prevMemberMax = null;
+            $boundariesAsc = true;
+            $boundariesDesc = true;
+
+            foreach ($chain as $m) {
+                $stats = $index->columnStats($m['entry'], $column);
+                if ($stats === null) {
+                    return null;
+                }
+
+                $mMin = null;
+                $mMax = null;
+                foreach ($stats['blocks'] as $block) {
+                    if ($block['count'] > 0) {
+                        $mMin = $mMin === null ? $block['min'] : min($mMin, $block['min']);
+                        $mMax = $mMax === null ? $block['max'] : max($mMax, $block['max']);
+                        $sum += $block['sum'];
+                        $count += $block['count'];
+                    }
+                    $other += $block['other'];
+                }
+
+                $allAsc = $allAsc && $stats['sorted_asc'];
+                $allDesc = $allDesc && $stats['sorted_desc'];
+
+                // Chain-level sortedness needs the member boundaries in
+                // order too. Member min/max include the header folded
+                // into block 0, which can only turn a true verdict into
+                // null (conservative-safe), never the reverse.
+                if ($mMin !== null) {
+                    if ($prevMemberMax !== null && $mMin < $prevMemberMax) {
+                        $boundariesAsc = false;
+                    }
+                    if ($prevMemberMin !== null && $mMax > $prevMemberMin) {
+                        $boundariesDesc = false;
+                    }
+                    $prevMemberMin = $mMin;
+                    $prevMemberMax = $mMax;
+                    $min = $min === null ? $mMin : min($min, $mMin);
+                    $max = $max === null ? $mMax : max($max, $mMax);
+                }
+            }
+
+            return [
+                'min' => $min,
+                'max' => $max,
+                'sum' => $sum,
+                'avg' => $count > 0 ? $sum / $count : null,
+                'count' => $count,
+                'other' => $other,
+                'sorted' => ($allAsc && $boundariesAsc) ? 'asc' : (($allDesc && $boundariesDesc) ? 'desc' : null),
+            ];
+        }
+
         $stats = $index?->columnStats($this->currentEntry, $column);
         if ($stats === null) {
             return null;
@@ -506,9 +724,49 @@ class StreamingXlsxReader
             throw new \InvalidArgumentException("quantile must be within [0, 1]; got {$q}");
         }
 
+        $chain = $this->chain();
+        if ($chain !== null) {
+            return $this->chainDigest($chain, $column)?->quantile($q);
+        }
+
         $digest = $this->loadRandomAccessIndex()?->columnDigest($this->currentEntry, $column);
 
         return $digest?->quantile($q);
+    }
+
+    /**
+     * Merged t-digest across a chain's members — the sketches' merge
+     * associativity is exactly what makes per-sheet sections compose
+     * into one logical-table answer. All-or-nothing like columnStats:
+     * a member without the sketch would make the merged answer cover
+     * part of the table, so the result is null instead. Memoized per
+     * (chain, column); the first member's digest is cloned so the
+     * sidecar's cached instances are never mutated.
+     *
+     * @param  list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>  $chain
+     */
+    private function chainDigest(array $chain, int $column): ?TDigest
+    {
+        $key = $chain[0]['entry'].'|'.$column;
+        if (array_key_exists($key, $this->chainDigestCache)) {
+            return $this->chainDigestCache[$key];
+        }
+
+        $index = $this->loadRandomAccessIndex();
+        $merged = null;
+        foreach ($chain as $m) {
+            $digest = $index?->columnDigest($m['entry'], $column);
+            if ($digest === null) {
+                return $this->chainDigestCache[$key] = null;
+            }
+            if ($merged === null) {
+                $merged = clone $digest;
+            } else {
+                $merged->merge($digest);
+            }
+        }
+
+        return $this->chainDigestCache[$key] = $merged;
     }
 
     /**
@@ -536,9 +794,51 @@ class StreamingXlsxReader
      */
     public function countDistinct(int $column): ?int
     {
+        $chain = $this->chain();
+        if ($chain !== null) {
+            return $this->chainHll($chain, $column)?->count();
+        }
+
         $hll = $this->loadRandomAccessIndex()?->columnHll($this->currentEntry, $column);
 
         return $hll?->count();
+    }
+
+    /**
+     * Merged HyperLogLog across a chain's members — register-wise max,
+     * the union sketch. Same all-or-nothing and clone-first rules as
+     * chainDigest(); a precision mismatch between members (impossible
+     * from one writer run, conceivable from a crafted sidecar) answers
+     * null rather than throwing mid-query.
+     *
+     * @param  list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>  $chain
+     */
+    private function chainHll(array $chain, int $column): ?HyperLogLog
+    {
+        $key = $chain[0]['entry'].'|'.$column;
+        if (array_key_exists($key, $this->chainHllCache)) {
+            return $this->chainHllCache[$key];
+        }
+
+        $index = $this->loadRandomAccessIndex();
+        $merged = null;
+        foreach ($chain as $m) {
+            $hll = $index?->columnHll($m['entry'], $column);
+            if ($hll === null) {
+                return $this->chainHllCache[$key] = null;
+            }
+            if ($merged === null) {
+                $merged = clone $hll;
+            } else {
+                try {
+                    $merged->merge($hll);
+                } catch (\InvalidArgumentException) {
+                    return $this->chainHllCache[$key] = null;
+                }
+            }
+        }
+
+        return $this->chainHllCache[$key] = $merged;
     }
 
     /**
@@ -561,26 +861,61 @@ class StreamingXlsxReader
      */
     public function rowsWhere(int $column, string $op, int|float $value, int|float|null $value2 = null): \Generator
     {
-        [$lo, $hi] = $this->pruneBounds($op, $value, $value2);
-
-        $index = $this->loadRandomAccessIndex();
-        $stats = $index?->columnStats($this->currentEntry, $column);
-
-        if ($stats === null) {
-            // No zone maps — scan everything, filter per row. NOT via
-            // rows(): that wrapper re-keys sequentially from 0, while
-            // this generator's contract (and the pruned path below) is
-            // 1-based sheet row numbers.
-            foreach ($this->openSheetReader([$column - 1])->rowsFromOffset(null, 1) as $rn => $row) {
-                if ($this->cellMatches($row[$column - 1] ?? null, $op, $value, $value2)) {
-                    yield $rn => $this->applyCasts($row);
+        // Chain: run the per-sheet matcher over every member in order,
+        // remapping local row numbers to the chain's global numbering.
+        // Continuation members' repeated header row (local 1) is
+        // filtered — it does not exist logically, and its local number
+        // would collide with the previous member's last data row after
+        // remapping.
+        $chain = $this->chain();
+        if ($chain !== null) {
+            foreach ($chain as $i => $m) {
+                foreach ($this->matchRowsIn($m['entry'], $column, $op, $value, $value2) as $rn => $row) {
+                    if ($i > 0 && $rn === 1) {
+                        continue;
+                    }
+                    yield $m['globalStart'] + ($rn - $m['dataStartLocal']) => $this->applyCasts($row);
                 }
             }
 
             return;
         }
 
-        $ranges = $this->blockRanges($index);
+        foreach ($this->matchRowsIn($this->currentEntry, $column, $op, $value, $value2) as $rn => $row) {
+            yield $rn => $this->applyCasts($row);
+        }
+    }
+
+    /**
+     * Single-sheet predicate matcher behind rowsWhere(): zone-map
+     * pruning + run-merged scans over one entry, yielding LOCAL 1-based
+     * row number => raw matched row (casts belong to the caller). This
+     * is the pre-v3.2.2 rowsWhere body parameterized by entry.
+     *
+     * @return \Generator<int, array<int, mixed>>
+     */
+    private function matchRowsIn(string $entry, int $column, string $op, int|float $value, int|float|null $value2): \Generator
+    {
+        [$lo, $hi] = $this->pruneBounds($op, $value, $value2);
+
+        $index = $this->loadRandomAccessIndex();
+        $stats = $index?->columnStats($entry, $column);
+
+        if ($stats === null) {
+            // No zone maps — scan everything, filter per row. NOT via
+            // rows(): that wrapper re-keys sequentially from 0, while
+            // this generator's contract (and the pruned path below) is
+            // 1-based sheet row numbers.
+            foreach ($this->openSheetReader([$column - 1], $entry)->rowsFromOffset(null, 1) as $rn => $row) {
+                if ($this->cellMatches($row[$column - 1] ?? null, $op, $value, $value2)) {
+                    yield $rn => $row;
+                }
+            }
+
+            return;
+        }
+
+        $ranges = $this->blockRanges($index, $entry);
 
         // Prune, then merge surviving adjacent blocks into runs so each
         // run costs one seek + one linear scan instead of per-block seeks.
@@ -603,7 +938,7 @@ class StreamingXlsxReader
             $start = $ranges[$firstBlock];
             $stopRow = $ranges[$lastBlock]['last_row'];
 
-            foreach ($this->openSheetReader([$column - 1])->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
+            foreach ($this->openSheetReader([$column - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
                 if ($rn < $start['first_row']) {
                     continue;
                 }
@@ -611,7 +946,7 @@ class StreamingXlsxReader
                     break;
                 }
                 if ($this->cellMatches($row[$column - 1] ?? null, $op, $value, $value2)) {
-                    yield $rn => $this->applyCasts($row);
+                    yield $rn => $row;
                 }
             }
         }
@@ -690,6 +1025,12 @@ class StreamingXlsxReader
      * Groups are returned in first-encounter sheet order — ascending
      * group keys for an asc-sorted column, descending for desc.
      *
+     * On an auto-split continuation chain the aggregation covers the
+     * whole logical table: members fold in workbook order, the same
+     * group key accumulates across members, and group order stays
+     * first-encounter across the chain. Each member keeps its own
+     * pushdown verdict (an unsorted member degrades to a scan alone).
+     *
      * @param  callable(float): (int|float)  $bucket
      * @return list<array{group: int|float, sum: float, count: int, min: float|null, max: float|null}>
      */
@@ -702,29 +1043,53 @@ class StreamingXlsxReader
         }
         $bucket ??= static fn (float $v): float => $v;
 
-        $index = $this->loadRandomAccessIndex();
-        $groupCol = $index?->columnStats($this->currentEntry, $groupBy);
-        $aggCol = $index?->columnStats($this->currentEntry, $aggregate);
-
         /** @var array<string, array{group: int|float, sum: float, count: int, min: float|null, max: float|null}> $groups */
         $groups = [];
+
+        $chain = $this->chain();
+        if ($chain !== null) {
+            foreach ($chain as $m) {
+                $this->foldGroupStatsFor($m['entry'], $groupBy, $aggregate, $bucket, $groups);
+            }
+        } else {
+            $this->foldGroupStatsFor($this->currentEntry, $groupBy, $aggregate, $bucket, $groups);
+        }
+
+        return array_values($groups);
+    }
+
+    /**
+     * Single-sheet engine behind groupStats(): the pre-v3.2.2 body
+     * parameterized by entry, folding into the caller's group map so
+     * chain members compose. The rn === 1 exclusions double as the
+     * continuation-header filter — a member's repeated header row is
+     * its local row 1.
+     *
+     * @param  callable(float): (int|float)  $bucket
+     * @param  array<string, array{group: int|float, sum: float, count: int, min: float|null, max: float|null}>  $groups
+     */
+    private function foldGroupStatsFor(string $entry, int $groupBy, int $aggregate, callable $bucket, array &$groups): void
+    {
+        $index = $this->loadRandomAccessIndex();
+        $groupCol = $index?->columnStats($entry, $groupBy);
+        $aggCol = $index?->columnStats($entry, $aggregate);
 
         if ($index === null || $groupCol === null || $aggCol === null
             || (! $groupCol['sorted_asc'] && ! $groupCol['sorted_desc'])) {
             // No pushdown basis — honest full scan with the same
             // grouping. Not via rows(): the scan must see 1-based row
             // numbers to exclude exactly the header.
-            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1])->rowsFromOffset(null, 1) as $rn => $row) {
+            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1], $entry)->rowsFromOffset(null, 1) as $rn => $row) {
                 if ($rn === 1) {
                     continue;
                 }
                 $this->foldRowIntoGroups($groups, $row, $groupBy, $aggregate, $bucket);
             }
 
-            return array_values($groups);
+            return;
         }
 
-        $ranges = $this->blockRanges($index);
+        $ranges = $this->blockRanges($index, $entry);
         $aggBlocks = $aggCol['blocks'];
 
         // Plan pass: classify every block in sheet order. Adjacent scan
@@ -785,7 +1150,7 @@ class StreamingXlsxReader
             [$first, $last] = $step['scan'];
             $start = $ranges[$first];
             $stopRow = $ranges[$last]['last_row'];
-            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1])->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
+            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
                 if ($rn > $stopRow) {
                     break;
                 }
@@ -795,8 +1160,6 @@ class StreamingXlsxReader
                 $this->foldRowIntoGroups($groups, $row, $groupBy, $aggregate, $bucket);
             }
         }
-
-        return array_values($groups);
     }
 
     /**
@@ -906,6 +1269,13 @@ class StreamingXlsxReader
      * The header row (row 1) rides in the first shard; skip $rn === 1
      * in workers if headers are handled elsewhere.
      *
+     * On an auto-split continuation chain the plan covers EVERY member
+     * sheet (pre-v3.2.2 it silently sharded the active sheet alone) —
+     * $count splits proportionally across members, at least one shard
+     * each. Shard row numbers stay local to their sheet, and every
+     * member's first shard carries that sheet's repeated header at
+     * local row 1, so the "skip $rn === 1" guidance applies per sheet.
+     *
      * @return list<array{sheet: string, comp_offset: int|null, start_row: int, first_row: int, last_row: int}>
      */
     public function shards(int $count): array
@@ -915,6 +1285,61 @@ class StreamingXlsxReader
         }
 
         $index = $this->loadRandomAccessIndex();
+
+        // Chain: fan-out must cover the whole logical table, so shards
+        // tile EVERY member sheet — each member gets a slice of the
+        // requested count proportional to its rows (never less than
+        // one), and workers cross sheets through rowsForShard()'s
+        // existing entry switch. Shard row numbers stay LOCAL to their
+        // sheet (the rowsForShard contract): each member's first shard
+        // carries that sheet's (repeated) header at local row 1, so the
+        // documented "skip rn === 1" worker guidance applies per sheet.
+        $chain = $this->chain();
+        if ($chain !== null && $index !== null) {
+            $memberCount = count($chain);
+            $effective = max($count, $memberCount);
+            $totals = array_column($chain, 'total');
+            $sumTotals = array_sum($totals);
+
+            // Largest-remainder allocation, floor-based with a 1-shard
+            // minimum per member; converges to exactly $effective.
+            $alloc = [];
+            $fracs = [];
+            $assigned = 0;
+            foreach ($totals as $i => $t) {
+                $exact = $sumTotals > 0 ? $effective * $t / $sumTotals : 1.0;
+                $alloc[$i] = max(1, (int) floor($exact));
+                $fracs[$i] = $exact - floor($exact);
+                $assigned += $alloc[$i];
+            }
+            while ($assigned < $effective) {
+                $best = array_search(max($fracs), $fracs, true);
+                $alloc[$best]++;
+                $fracs[$best] = -1.0;
+                $assigned++;
+            }
+            while ($assigned > $effective) {
+                $worst = null;
+                foreach ($alloc as $i => $a) {
+                    if ($a > 1 && ($worst === null || $a > $alloc[$worst])) {
+                        $worst = $i;
+                    }
+                }
+                if ($worst === null) {
+                    break; // every member at the 1-shard floor already
+                }
+                $alloc[$worst]--;
+                $assigned--;
+            }
+
+            $out = [];
+            foreach ($chain as $i => $m) {
+                $out = array_merge($out, $this->shardsFor($index, $m['entry'], $alloc[$i]));
+            }
+
+            return $out;
+        }
+
         $total = $index?->totalRows($this->currentEntry);
 
         $wholeSheet = [[
@@ -929,7 +1354,34 @@ class StreamingXlsxReader
             return $wholeSheet;
         }
 
-        $points = $index->syncPoints($this->currentEntry);
+        return $this->shardsFor($index, $this->currentEntry, $count);
+    }
+
+    /**
+     * Single-sheet shard planner behind shards(): the pre-v3.2.2 body
+     * parameterized by entry. Cut points snap to the entry's sync
+     * points; duplicate picks collapse, so tiny sheets yield fewer
+     * shards than requested.
+     *
+     * @return list<array{sheet: string, comp_offset: int|null, start_row: int, first_row: int, last_row: int}>
+     */
+    private function shardsFor(RandomAccessIndex $index, string $entry, int $count): array
+    {
+        $total = $index->totalRows($entry);
+
+        $wholeSheet = [[
+            'sheet' => $entry,
+            'comp_offset' => null,
+            'start_row' => 1,
+            'first_row' => 1,
+            'last_row' => $total ?? PHP_INT_MAX,
+        ]];
+
+        if ($total === null || $count === 1) {
+            return $wholeSheet;
+        }
+
+        $points = $index->syncPoints($entry);
         if ($points === []) {
             return $wholeSheet;
         }
@@ -959,7 +1411,7 @@ class StreamingXlsxReader
                 continue; // collapsed duplicate — would create an empty shard
             }
             $shards[] = [
-                'sheet' => $this->currentEntry,
+                'sheet' => $entry,
                 'comp_offset' => $compOffset,
                 'start_row' => $startRow,
                 'first_row' => $firstRow,
@@ -970,7 +1422,7 @@ class StreamingXlsxReader
             $startRow = $cut['row'];
         }
         $shards[] = [
-            'sheet' => $this->currentEntry,
+            'sheet' => $entry,
             'comp_offset' => $compOffset,
             'start_row' => $startRow,
             'first_row' => $firstRow,
@@ -1104,9 +1556,11 @@ class StreamingXlsxReader
      *
      * @return list<array{first_row: int, last_row: int, comp_offset: int|null, uncomp_offset: int|null, start_row_at_offset: int|null}>
      */
-    private function blockRanges(RandomAccessIndex $index): array
+    private function blockRanges(RandomAccessIndex $index, ?string $entry = null): array
     {
-        return $this->blockRangesByEntry[$this->currentEntry] ??= $index->blockRanges($this->currentEntry);
+        $entry ??= $this->currentEntry;
+
+        return $this->blockRangesByEntry[$entry] ??= $index->blockRanges($entry);
     }
 
     /**
@@ -1117,13 +1571,13 @@ class StreamingXlsxReader
      *
      * @return array{0: int|null, 1: int}
      */
-    private function seekTarget(int $rowNumber): array
+    private function seekTarget(int $rowNumber, ?string $entry = null): array
     {
         $index = $this->loadRandomAccessIndex();
         if ($index === null) {
             return [null, 1];
         }
-        $sp = $index->findSyncPoint($this->currentEntry, $rowNumber);
+        $sp = $index->findSyncPoint($entry ?? $this->currentEntry, $rowNumber);
         if ($sp === null) {
             return [null, 1];
         }
@@ -1327,12 +1781,12 @@ class StreamingXlsxReader
      *                                 aggregation semantics don't change
      *                                 underneath them
      */
-    private function openSheetReader(array $rawColumns = []): StreamingSheetReader
+    private function openSheetReader(array $rawColumns = [], ?string $entry = null): StreamingSheetReader
     {
         return new StreamingSheetReader(
             $this->source,
             $this->cd,
-            $this->currentEntry,
+            $entry ?? $this->currentEntry,
             65536,
             $this->resolveSharedStrings(),
             $this->buildDateDetection($rawColumns),
@@ -1401,6 +1855,142 @@ class StreamingXlsxReader
         return $this->dateStyleBitmap = StylesParser::dateStyleBitmap(
             $this->cd->readEntry($this->source, 'xl/styles.xml')
         );
+    }
+
+    /**
+     * The continuation chain containing the current sheet, or null when
+     * the sheet stands alone (single-sheet workbook, no usable sidecar,
+     * or a chain of one). Every query API branches on this ONCE — the
+     * null path is the pre-v3.2.2 code, byte-for-byte.
+     *
+     * @return list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>|null
+     */
+    private function chain(): ?array
+    {
+        if (count($this->sheets) < 2) {
+            return null;
+        }
+        $index = $this->loadRandomAccessIndex();
+        if ($index === null) {
+            return null;
+        }
+
+        $this->resolveChains($index);
+
+        $chain = $this->chainByEntry[$this->currentEntry] ?? null;
+
+        return $chain !== null && count($chain) > 1 ? $chain : null;
+    }
+
+    /**
+     * Partition the workbook's sheets into continuation chains. Runs at
+     * most once per reader. Header reads happen ONLY for sheets
+     * adjacent to an exactly-full one (the && short-circuit), so
+     * workbooks without any full sheet — the overwhelming majority —
+     * never pay a single extra read here.
+     */
+    private function resolveChains(RandomAccessIndex $index): void
+    {
+        if ($this->chainByEntry !== null) {
+            return;
+        }
+        $this->chainByEntry = [];
+
+        $runs = [];
+        $run = [$this->sheets[0]['entry']];
+        for ($i = 1, $n = count($this->sheets); $i < $n; $i++) {
+            $prev = $this->sheets[$i - 1]['entry'];
+            $cur = $this->sheets[$i]['entry'];
+
+            $continues = $index->totalRows($prev) === self::FULL_SHEET_ROWS
+                && $index->totalRows($cur) !== null
+                && $this->rawHeaderOf($prev) !== []
+                && $this->rawHeaderOf($cur) === $this->rawHeaderOf($prev);
+
+            if ($continues) {
+                $run[] = $cur;
+            } else {
+                $runs[] = $run;
+                $run = [$cur];
+            }
+        }
+        $runs[] = $run;
+
+        foreach ($runs as $entries) {
+            $members = [];
+            $globalStart = 1;
+            foreach ($entries as $j => $entry) {
+                $total = $index->totalRows($entry) ?? 0;
+                $dataStartLocal = $j === 0 ? 1 : 2;
+                $members[] = [
+                    'entry' => $entry,
+                    'total' => $total,
+                    'dataStartLocal' => $dataStartLocal,
+                    'globalStart' => $globalStart,
+                ];
+                $globalStart += $total - $dataStartLocal + 1;
+            }
+            foreach ($entries as $entry) {
+                $this->chainByEntry[$entry] = $members;
+            }
+        }
+    }
+
+    /**
+     * Raw tokenized header row of an arbitrary entry — casts and date
+     * detection deliberately bypassed so equality means "same bytes on
+     * disk", the only sound continuation test.
+     *
+     * @return array<int, mixed>
+     */
+    private function rawHeaderOf(string $entry): array
+    {
+        if (! array_key_exists($entry, $this->headerByEntry)) {
+            $this->headerByEntry[$entry] = [];
+            $reader = new StreamingSheetReader($this->source, $this->cd, $entry, 65536, $this->resolveSharedStrings(), null);
+            foreach ($reader->rows() as $row) {
+                $this->headerByEntry[$entry] = $row;
+                break;
+            }
+        }
+
+        return $this->headerByEntry[$entry];
+    }
+
+    /**
+     * Global logical row count of a chain: member 1 in full, plus every
+     * continuation member's rows minus its repeated header.
+     *
+     * @param  list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>  $chain
+     */
+    private function chainTotalRows(array $chain): int
+    {
+        $last = end($chain);
+
+        return $last['globalStart'] + $last['total'] - $last['dataStartLocal'];
+    }
+
+    /**
+     * Map a global row number to [member index, local row] — the
+     * inverse of the member globalStart/dataStartLocal bookkeeping.
+     * Null when the target lies past the chain's end (or below 1).
+     *
+     * @param  list<array{entry: string, total: int, dataStartLocal: int, globalStart: int}>  $chain
+     * @return array{0: int, 1: int}|null
+     */
+    private function chainLocate(array $chain, int $globalRow): ?array
+    {
+        if ($globalRow < 1) {
+            return null;
+        }
+        foreach ($chain as $i => $m) {
+            $coverEnd = $m['globalStart'] + $m['total'] - $m['dataStartLocal'];
+            if ($globalRow <= $coverEnd) {
+                return [$i, $m['dataStartLocal'] + ($globalRow - $m['globalStart'])];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -571,6 +571,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
         // Allowed before startFile() (for sheet 1) and between newSheet() calls
         // (to give each manually-rotated sheet its own header style).
         $this->headerStyleId = $this->styles->registerHeaderStyle($options);
@@ -630,6 +631,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
         if ($rows < 0 || $columns < 0) {
             throw new XlsxStreamException('Freeze rows/columns must be >= 0.');
         }
@@ -656,6 +658,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
         foreach ($widths as $col => $width) {
             if ($col < 1) {
                 throw new XlsxStreamException("Column index must be >= 1, got {$col}.");
@@ -697,6 +700,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
 
         if (is_int($sample)) {
             if ($sample < 0) {
@@ -764,6 +768,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
         if ($column < 1) {
             throw new XlsxStreamException("Column index must be >= 1, got {$column}.");
         }
@@ -807,6 +812,7 @@ abstract class BaseXlsxWriter
         if ($this->closed) {
             throw XlsxStreamException::writerAlreadyClosed();
         }
+        $this->finalizePendingSample();
         $this->columnStyleIds = [];
         $this->columnFormatNames = [];
         $this->columnWidths = [];
@@ -991,6 +997,28 @@ abstract class BaseXlsxWriter
      * Sample size reached — compute widths, emit preamble (now with the
      * computed <cols>) + header, drain the sample buffer.
      */
+    /**
+     * Finalize the active sheet's pending auto-width sample, if any.
+     *
+     * Config mutations must never act retroactively on an already-
+     * written (or pending) sheet preamble. In sample mode the preamble
+     * is deferred until the sample drains — without this guard, a
+     * mutator called while the sample is pending (the natural "prepare
+     * the NEXT sheet, then newSheet()" flow) would rewrite the CURRENT
+     * sheet's header style, wipe its explicit widths, or leak the next
+     * sheet's formats into it. Every config mutator that feeds the
+     * preamble calls this first, so a pending sample is finalized with
+     * exactly the state it was sampled under before the mutation lands.
+     *
+     * Cost when no sample is pending: three property reads.
+     */
+    protected function finalizePendingSample(): void
+    {
+        if ($this->started && $this->inSampleMode && ! $this->autoWidthFinalized) {
+            $this->finalizeAutoWidthSample();
+        }
+    }
+
     protected function finalizeAutoWidthSample(): void
     {
         foreach ($this->autoWidthMaxLengths as $col => $maxLen) {
@@ -1775,6 +1803,19 @@ abstract class BaseXlsxWriter
             'percent' => 10,                 // 100.00%
             'decimal' => 14,                 // 1,234,567.89
             'integer' => 14,                 // 1,234,567,890 (10-digit grouped)
+            'builtin:'.self::BUILTIN_NUMFMT_INTEGER => 14,       // 1
+            'builtin:'.self::BUILTIN_NUMFMT_DECIMAL_2 => 14,     // 2
+            'builtin:'.self::BUILTIN_NUMFMT_THOUSANDS => 14,     // 3
+            'builtin:'.self::BUILTIN_NUMFMT_CURRENCY => 14,      // 5
+            'builtin:'.self::BUILTIN_NUMFMT_PERCENT => 10,       // 9
+            'builtin:'.self::BUILTIN_NUMFMT_PERCENT_2 => 10,     // 10
+            'builtin:'.self::BUILTIN_NUMFMT_EXPONENT => 11,      // 11
+            'builtin:'.self::BUILTIN_NUMFMT_FRACTION => 10,      // 12
+            'builtin:'.self::BUILTIN_NUMFMT_DATE => 12,          // 14
+            'builtin:'.self::BUILTIN_NUMFMT_DATE_LONG => 13,     // 15
+            'builtin:'.self::BUILTIN_NUMFMT_TIME_AMPM => 11,     // 18
+            'builtin:'.self::BUILTIN_NUMFMT_TIME => 10,          // 20
+            'builtin:'.self::BUILTIN_NUMFMT_DATETIME => 20,      // 22
             default => 0,
         };
     }

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -276,6 +276,65 @@ abstract class BaseXlsxWriter
     public function __construct()
     {
         $this->styles = new StyleRegistry();
+
+        // Laravel-published config defaults. Guarded so the package
+        // stays framework-optional: outside Laravel config() either
+        // does not exist or has no container behind it (the helper is
+        // defined by illuminate/support even without an app booted —
+        // hence the try/catch, not just function_exists).
+        if (\function_exists('config')) {
+            try {
+                $cfg = config('xlsx-stream');
+            } catch (\Throwable) {
+                $cfg = null;
+            }
+            $this->applyConfigDefaults(is_array($cfg) ? $cfg : null);
+        }
+    }
+
+    /**
+     * Fold the published config's writer defaults into this instance.
+     *
+     * Precedence: code-level setters > config > package defaults. The
+     * config is applied once at construction, so any setter the caller
+     * invokes afterwards naturally overrides it.
+     *
+     * Version gate: copies of config/xlsx-stream.php published before
+     * v3.2.2 carried keys the package never read, with stale values
+     * that contradict the code defaults (compression_level 1 vs the
+     * writer's real default 5). Honouring them retroactively would
+     * silently change existing applications' output, so only configs
+     * declaring `'version' => 2` (the v3.2.2+ file) are applied —
+     * older published copies stay inert, exactly as they always were.
+     *
+     * Invalid values are silently ignored rather than thrown: this
+     * runs in the constructor, and a config file is environment data,
+     * not code — a bad env var must not turn every `new Writer` into
+     * a 500. The setters keep throwing for code-level misuse.
+     */
+    protected function applyConfigDefaults(?array $config): void
+    {
+        if ((int) ($config['version'] ?? 0) < 2) {
+            return;
+        }
+
+        $level = $config['writer']['compression_level'] ?? null;
+        if (is_numeric($level)) {
+            try {
+                $this->setCompressionLevel((int) $level);
+            } catch (\Throwable) {
+                // out-of-range config value — keep the package default
+            }
+        }
+
+        $interval = $config['writer']['buffer_flush_interval'] ?? null;
+        if (is_numeric($interval)) {
+            try {
+                $this->setBufferFlushInterval((int) $interval);
+            } catch (\Throwable) {
+                // out-of-range config value — keep the package default
+            }
+        }
     }
 
     /**

--- a/src/Writers/SinkableXlsxWriter.php
+++ b/src/Writers/SinkableXlsxWriter.php
@@ -49,6 +49,11 @@ class SinkableXlsxWriter extends BaseXlsxWriter
      * Pass `$putObjectParams` (e.g. `['ACL' => 'public-read']`) for S3-only
      * options. They are ignored for local disks.
      *
+     * $partSize resolution: an explicit argument wins; otherwise the
+     * published config's `xlsx-stream.s3.part_size` (version-2+ config
+     * only — see BaseXlsxWriter::applyConfigDefaults() for the gate's
+     * rationale); otherwise the sink default (8 MB).
+     *
      * @throws XlsxStreamException when the disk is not configured or the
      *                             driver is not supported.
      */
@@ -56,7 +61,7 @@ class SinkableXlsxWriter extends BaseXlsxWriter
         string $disk,
         string $path,
         array $putObjectParams = [],
-        int $partSize = S3MultipartSink::DEFAULT_PART_SIZE
+        ?int $partSize = null
     ): self {
         if (! function_exists('config')) {
             throw new XlsxStreamException(
@@ -86,12 +91,15 @@ class SinkableXlsxWriter extends BaseXlsxWriter
                 'use_path_style_endpoint' => $config['use_path_style_endpoint'] ?? false,
             ]);
 
+            $packageConfig = self::packageConfig();
+
             $sink = new S3MultipartSink(
                 $client,
                 $config['bucket'] ?? '',
                 $path,
-                $partSize,
-                $putObjectParams
+                self::resolvePartSize($partSize, $packageConfig),
+                $putObjectParams,
+                self::resolveConcurrency($packageConfig)
             );
 
             return new self($sink);
@@ -108,6 +116,67 @@ class SinkableXlsxWriter extends BaseXlsxWriter
             "Disk [{$disk}] driver [{$driver}] is not supported. ".
             'Supported drivers: s3, local.'
         );
+    }
+
+    /**
+     * The package's published config, or null outside Laravel / when
+     * the container can't serve it — the same guard the base writer's
+     * constructor uses for its own defaults.
+     */
+    private static function packageConfig(): ?array
+    {
+        if (! function_exists('config')) {
+            return null;
+        }
+        try {
+            $cfg = config('xlsx-stream');
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return is_array($cfg) ? $cfg : null;
+    }
+
+    /**
+     * Part-size precedence for forDisk(): explicit argument > version-2+
+     * config's s3.part_size > sink default. Invalid config values fall
+     * through to the default — config is environment data, not code
+     * (see BaseXlsxWriter::applyConfigDefaults()); the sink additionally
+     * raises anything below S3's 5 MB minimum on its own.
+     */
+    protected static function resolvePartSize(?int $explicit, ?array $config): int
+    {
+        if ($explicit !== null) {
+            return $explicit;
+        }
+
+        if ((int) ($config['version'] ?? 0) >= 2) {
+            $size = $config['s3']['part_size'] ?? null;
+            if (is_numeric($size) && (int) $size >= 1) {
+                return (int) $size;
+            }
+        }
+
+        return S3MultipartSink::DEFAULT_PART_SIZE;
+    }
+
+    /**
+     * Upload-window concurrency for forDisk(): version-2+ config's
+     * s3.concurrency > sink default. No explicit-argument tier —
+     * forDisk()'s signature stays put; callers needing per-call control
+     * construct S3MultipartSink directly (its constructor takes
+     * concurrency). Same invalid-value policy as resolvePartSize().
+     */
+    protected static function resolveConcurrency(?array $config): int
+    {
+        if ((int) ($config['version'] ?? 0) >= 2) {
+            $value = $config['s3']['concurrency'] ?? null;
+            if (is_numeric($value) && (int) $value >= 1) {
+                return (int) $value;
+            }
+        }
+
+        return S3MultipartSink::DEFAULT_CONCURRENCY;
     }
 
     protected function writeToDest(string $data): void

--- a/tests/Readers/AutoSplitSpanTest.php
+++ b/tests/Readers/AutoSplitSpanTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * v3.2.2 correctness fix (BRAINSTORM F2): on auto-split workbooks the
+ * whole query surface silently answered from the ACTIVE sheet only —
+ * a 2.1M-row export reported rowCount 1,048,575, findRow() returned
+ * null for rows past the first sheet, columnStats() summed less than
+ * half the data. These tests were written RED against v3.2.1 behaviour
+ * and pin the spanning semantics:
+ *
+ *   - A continuation CHAIN is a maximal run of consecutive sheets where
+ *     every non-final member is exactly full (1,048,575 rows including
+ *     its header) and every member carries an identical header row.
+ *     Only born-indexed files are chain-detected (the sidecar provides
+ *     the O(1) row totals the detection needs).
+ *   - Chain = ONE logical table. Global row numbers count sheet 1 in
+ *     full and continuation members' data rows only (their repeated
+ *     header rows do not exist logically): data row i sits at global
+ *     row i + 1.
+ *   - Explicitly different tables (newSheet with different headers, or
+ *     non-full sheets) are never chained — per-sheet semantics stay.
+ *
+ * The fixture is written once per class (2 full sheets + a 5,000-row
+ * tail, ~2.1M rows) with closed-form cell values so every oracle below
+ * is arithmetic, not a re-scan: id column = data row index, amount =
+ * 2*id, city = 'c' . (id % 5).
+ */
+class AutoSplitSpanTest extends TestCase
+{
+    private const FULL_SHEET_ROWS = 1_048_575;      // rows per full sheet incl. header
+
+    private const DATA_PER_FULL_SHEET = self::FULL_SHEET_ROWS - 1;
+
+    private const TAIL_DATA_ROWS = 5_000;
+
+    private const DATA_ROWS = 2 * self::DATA_PER_FULL_SHEET + self::TAIL_DATA_ROWS;
+
+    private const GLOBAL_ROWS = self::DATA_ROWS + 1; // one logical header
+
+    private static ?string $file = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $path = sys_get_temp_dir().'/kxs-autosplit-span-'.uniqid('', true).'.xlsx';
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->withRandomAccessIndex(every: 10_000);
+        $writer->withColumnStats([1, 2]);
+        $writer->withColumnSketches([1, 2]);
+        $writer->startFile(['id', 'amount', 'city', 'flag']);
+
+        for ($i = 1; $i <= self::DATA_ROWS; $i++) {
+            $writer->writeRow([$i, 2 * $i, 'c'.($i % 5), $i % 2 === 0]);
+        }
+        $writer->finishFile();
+
+        self::$file = $path;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$file !== null) {
+            @unlink(self::$file);
+            self::$file = null;
+        }
+        parent::tearDownAfterClass();
+    }
+
+    private function reader(): StreamingXlsxReader
+    {
+        return StreamingXlsxReader::fromFile(self::$file);
+    }
+
+    /** The writer really did split: 3 sheets, first two exactly full. */
+    public function test_fixture_shape(): void
+    {
+        $sheets = $this->reader()->sheets();
+
+        $this->assertCount(3, $sheets);
+    }
+
+    public function test_row_count_spans_the_chain(): void
+    {
+        $this->assertSame(self::GLOBAL_ROWS, $this->reader()->rowCount());
+    }
+
+    public function test_column_stats_cover_every_data_row(): void
+    {
+        $stats = $this->reader()->columnStats(1);
+
+        $this->assertNotNull($stats);
+        $this->assertSame(self::DATA_ROWS, $stats['count']);
+        $this->assertSame(1.0, $stats['min']);
+        $this->assertSame((float) self::DATA_ROWS, $stats['max']);
+        // Σ 1..D — exact in float64 well past 2^53 only in sum of ~2.2e12;
+        // compare against the closed form computed the same way.
+        $d = (float) self::DATA_ROWS;
+        $this->assertSame($d * ($d + 1.0) / 2.0, $stats['sum']);
+        // 'other' carries one text header cell per physical sheet.
+        $this->assertSame(3, $stats['other']);
+        $this->assertSame('asc', $stats['sorted']);
+    }
+
+    public function test_find_row_reaches_past_the_first_sheet(): void
+    {
+        $hit = $this->reader()->findRow(1, 2_000_000);
+
+        $this->assertNotNull($hit);
+        $this->assertSame(2_000_001, $hit['row']);
+        $this->assertSame('2000000', (string) $hit['values'][0]);
+        $this->assertSame('4000000', (string) $hit['values'][1]);
+    }
+
+    public function test_row_at_uses_global_numbering(): void
+    {
+        $row = $this->reader()->rowAt(2_000_001);
+
+        $this->assertNotNull($row);
+        $this->assertSame('2000000', (string) $row[0]);
+
+        // Global row 1 stays the (single logical) header.
+        $this->assertSame('id', $this->reader()->rowAt(1)[0]);
+
+        // Past-the-end stays null.
+        $this->assertNull($this->reader()->rowAt(self::GLOBAL_ROWS + 1));
+    }
+
+    public function test_row_range_crosses_the_sheet_boundary_seamlessly(): void
+    {
+        // Global rows 1,048,574..1,048,578 straddle sheet1 -> sheet2.
+        // Data ids run 1,048,573..1,048,577 with no gap and no repeated
+        // header row in between.
+        $got = [];
+        foreach ($this->reader()->rowRange(1_048_574, 1_048_578) as $rn => $row) {
+            $got[$rn] = (int) $row[0];
+        }
+
+        $this->assertSame([
+            1_048_574 => 1_048_573,
+            1_048_575 => 1_048_574,
+            1_048_576 => 1_048_575,
+            1_048_577 => 1_048_576,
+            1_048_578 => 1_048_577,
+        ], $got);
+    }
+
+    public function test_rows_skip_lands_in_a_later_sheet(): void
+    {
+        $got = [];
+        foreach ($this->reader()->rows(skip: self::GLOBAL_ROWS - 2) as $row) {
+            $got[] = (int) $row[0];
+        }
+
+        $this->assertSame([self::DATA_ROWS - 1, self::DATA_ROWS], $got);
+    }
+
+    public function test_rows_where_matches_in_a_later_sheet_with_global_keys(): void
+    {
+        $got = [];
+        foreach ($this->reader()->rowsWhere(1, 'between', 2_000_000, 2_000_004) as $rn => $row) {
+            $got[$rn] = (int) $row[0];
+        }
+
+        $this->assertSame([
+            2_000_001 => 2_000_000,
+            2_000_002 => 2_000_001,
+            2_000_003 => 2_000_002,
+            2_000_004 => 2_000_003,
+            2_000_005 => 2_000_004,
+        ], $got);
+    }
+
+    public function test_group_stats_span_the_chain(): void
+    {
+        // bucket = intdiv(id, 500_000) — monotone over the sorted id
+        // column; group g covers ids max(1, 500_000g)..min(D, 500_000g+499_999).
+        $groups = $this->reader()->groupStats(1, 2, fn (float $v) => intdiv((int) $v, 500_000));
+
+        $byKey = [];
+        foreach ($groups as $g) {
+            $byKey[(int) $g['group']] = $g;
+        }
+
+        // Ids reach 2,102,148 -> buckets 0..4 must ALL be present
+        // (bucket 4 starts at id 2,000,000 — entirely inside sheet 3's
+        // chain territory, invisible without spanning).
+        $this->assertSame([0, 1, 2, 3, 4], array_keys($byKey));
+
+        foreach ($byKey as $bucket => $g) {
+            $lo = max(1, $bucket * 500_000);
+            $hi = min(self::DATA_ROWS, $bucket * 500_000 + 499_999);
+            $n = $hi - $lo + 1;
+            $this->assertSame($n, $g['count'], "bucket {$bucket} count");
+            // amount = 2*id -> sum = 2 * Σ lo..hi
+            $expected = (float) ($lo + $hi) * $n; // 2 * (lo+hi)*n/2
+            $this->assertSame($expected, $g['sum'], "bucket {$bucket} sum");
+            $this->assertSame((float) (2 * $lo), $g['min']);
+            $this->assertSame((float) (2 * $hi), $g['max']);
+        }
+    }
+
+    public function test_sketches_cover_the_chain(): void
+    {
+        $reader = $this->reader();
+
+        // q=1 is the digest's exact max — chain merge must surface the
+        // global maximum, not sheet 1's.
+        $this->assertSame((float) self::DATA_ROWS, $reader->quantile(1, 1.0));
+        $this->assertSame(1.0, $reader->quantile(1, 0.0));
+
+        // Median of 1..D ≈ D/2 within the documented rank error.
+        $median = $reader->median(1);
+        $this->assertNotNull($median);
+        $this->assertEqualsWithDelta(self::DATA_ROWS / 2, $median, self::DATA_ROWS * 0.01);
+
+        // Distinct ids ≈ D (±2.3% documented; ±5% CI bound). Sheet-1-only
+        // behaviour (~1.05M) sits 50% off and can never pass this.
+        $distinct = $reader->countDistinct(1);
+        $this->assertNotNull($distinct);
+        $this->assertEqualsWithDelta(self::DATA_ROWS, $distinct, self::DATA_ROWS * 0.05);
+    }
+
+    public function test_shards_cover_every_chain_sheet(): void
+    {
+        $shards = $this->reader()->shards(6);
+
+        $sheetsCovered = array_unique(array_column($shards, 'sheet'));
+        sort($sheetsCovered);
+
+        $this->assertSame([
+            'xl/worksheets/sheet1.xml',
+            'xl/worksheets/sheet2.xml',
+            'xl/worksheets/sheet3.xml',
+        ], $sheetsCovered);
+
+        // Shards must tile each sheet's rows exactly (local numbering,
+        // headers ride at local row 1 of their first shard).
+        $bySheet = [];
+        foreach ($shards as $shard) {
+            $bySheet[$shard['sheet']][] = $shard;
+        }
+        foreach ($bySheet as $sheet => $list) {
+            $this->assertSame(1, $list[0]['first_row'], "{$sheet} first shard");
+            for ($i = 1; $i < count($list); $i++) {
+                $this->assertSame(
+                    $list[$i - 1]['last_row'] + 1,
+                    $list[$i]['first_row'],
+                    "{$sheet} shard {$i} continuity"
+                );
+            }
+        }
+        $this->assertSame(self::FULL_SHEET_ROWS, end($bySheet['xl/worksheets/sheet1.xml'])['last_row']);
+        $this->assertSame(self::TAIL_DATA_ROWS + 1, end($bySheet['xl/worksheets/sheet3.xml'])['last_row']);
+    }
+
+    public function test_selecting_a_chain_member_still_answers_for_the_whole_chain(): void
+    {
+        // A chain is one logical table; onSheet() into a member does not
+        // shrink the query surface back to a physical sheet.
+        $reader = $this->reader()->onSheetIndex(1);
+
+        $this->assertSame(self::GLOBAL_ROWS, $reader->rowCount());
+        $this->assertSame((float) self::DATA_ROWS, $reader->columnStats(1)['max']);
+    }
+
+    // ------------------------------------------------------------------
+    // Negative controls: chains must NOT form here.
+    // ------------------------------------------------------------------
+
+    public function test_distinct_tables_are_not_chained(): void
+    {
+        $path = sys_get_temp_dir().'/kxs-span-neg1-'.uniqid('', true).'.xlsx';
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->withRandomAccessIndex();
+        $writer->withColumnStats([1]);
+        $writer->startFile(['id', 'name']);
+        for ($i = 1; $i <= 100; $i++) {
+            $writer->writeRow([$i, 'a'.$i]);
+        }
+        $writer->newSheet('Totals', ['region', 'sum']);
+        for ($i = 1; $i <= 10; $i++) {
+            $writer->writeRow([$i * 1000, 'r'.$i]);
+        }
+        $writer->finishFile();
+
+        try {
+            $reader = StreamingXlsxReader::fromFile($path);
+            // Sheet 1 is not full -> no chain; per-sheet semantics intact.
+            $this->assertSame(101, $reader->rowCount());
+            $this->assertSame(100.0, $reader->columnStats(1)['max']);
+
+            $reader->onSheet('Totals');
+            $this->assertSame(11, $reader->rowCount());
+            $this->assertSame(10000.0, $reader->columnStats(1)['max']);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function test_same_header_partial_sheets_are_not_chained(): void
+    {
+        $path = sys_get_temp_dir().'/kxs-span-neg2-'.uniqid('', true).'.xlsx';
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->withRandomAccessIndex();
+        $writer->withColumnStats([1]);
+        $writer->startFile(['id', 'name']);
+        for ($i = 1; $i <= 50; $i++) {
+            $writer->writeRow([$i, 'a'.$i]);
+        }
+        // Same header layout, explicitly separate sheet — sheet 1 is not
+        // full, so this is two tables that happen to share a schema.
+        $writer->newSheet('Q2');
+        for ($i = 51; $i <= 80; $i++) {
+            $writer->writeRow([$i, 'a'.$i]);
+        }
+        $writer->finishFile();
+
+        try {
+            $reader = StreamingXlsxReader::fromFile($path);
+            $this->assertSame(51, $reader->rowCount());
+            $this->assertSame(50.0, $reader->columnStats(1)['max']);
+
+            $reader->onSheet('Q2');
+            $this->assertSame(31, $reader->rowCount());
+            $this->assertSame(80.0, $reader->columnStats(1)['max']);
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/tests/Writers/AutoWidthConfigMutationTest.php
+++ b/tests/Writers/AutoWidthConfigMutationTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\BaseXlsxWriter as W;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * v3.2.2 manual-Excel-test findings, written RED against the pre-fix
+ * writer:
+ *
+ * 1. Sample auto-width defers the active sheet's preamble, so config
+ *    mutations issued while a sample is pending used to act
+ *    RETROACTIVELY on the sheet being written: clearColumnFormats()
+ *    before newSheet() wiped the previous sheet's explicit
+ *    setColumnWidths() entry (observed 40 -> 131), and a header style
+ *    set for the NEXT sheet repainted the PREVIOUS sheet's header.
+ *    The fix pins the principle: config mutations never act
+ *    retroactively — a pending sample is finalized (with the state it
+ *    was sampled under) before the mutation lands.
+ *
+ * 2. minWidthForFormat() only knew NAMED format presets; columns
+ *    formatted via BUILTIN_NUMFMT_* ids fell back to width 8 in
+ *    heuristic mode and rendered as ###### in Excel. Builtin ids now
+ *    map to the same minimum-width table — <cols> hints only, cell
+ *    bytes are pinned unchanged.
+ */
+class AutoWidthConfigMutationTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-widthmut-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /**
+     * The documented multi-sheet order — clear + configure the NEXT
+     * sheet, then newSheet() — must not corrupt the sheet whose sample
+     * is still pending: its explicit width survives, its header keeps
+     * the style that was active while it was written, and the next
+     * sheet gets the new style/formats.
+     */
+    public function test_pre_new_sheet_cleanup_does_not_corrupt_pending_sample_sheet(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth(sample: 100); // stays pending past every row below
+        $writer->setColumnWidths([2 => 10]);
+        $writer->setHeaderStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF']);
+        $writer->setColumnFormat(3, W::BUILTIN_NUMFMT_CURRENCY);
+        $writer->startFile(['id', 'desc', 'price']);
+
+        for ($i = 1; $i <= 5; $i++) {
+            $writer->writeRow([$i, 'a deliberately long description well past ten chars', 12.5 * $i]);
+        }
+
+        // Prepare sheet 2 (different layout) the documented way.
+        $writer->clearColumnFormats();
+        $writer->setColumnFormat(2, W::BUILTIN_NUMFMT_DATE);
+        $writer->setHeaderStyle(['fill' => '#375623', 'color' => '#FFFFFF']);
+        $writer->newSheet('S2', ['when', 'date']);
+        $writer->writeRow(['x', new \DateTimeImmutable('2026-01-15')]);
+        $writer->finishFile();
+
+        // (ii) sheet 1 keeps the user width 10 on col 2 — pre-fix the
+        // pending sample won with the long-description width.
+        $this->assertStringContainsString(
+            '<col min="2" max="2" width="10"',
+            $this->sheetXml(1),
+            'explicit setColumnWidths entry must survive a pre-newSheet clearColumnFormats'
+        );
+
+        // (iii) sheet 1's header keeps ITS style; sheet 2 gets the new
+        // one — pre-fix both carried the second style id.
+        $s1 = $this->headerStyleIdOf(1);
+        $s2 = $this->headerStyleIdOf(2);
+        $this->assertNotNull($s1);
+        $this->assertNotNull($s2);
+        $this->assertNotSame($s1, $s2, 'a header style set for the NEXT sheet must not repaint the pending sheet');
+
+        // (iv) each sheet's own column format landed on its data cells.
+        $this->assertMatchesRegularExpression('/<c r="C2" s="\d+" t="n">/', $this->sheetXml(1));
+        $this->assertMatchesRegularExpression('/<c r="B2" s="\d+" t="n">/', $this->sheetXml(2));
+    }
+
+    /**
+     * Changing the header style mid-sheet (while the sample is pending)
+     * finalizes the pending sheet with the OLD style; the new style
+     * only applies from the next sheet on. Rows written after the
+     * early finalize keep flowing normally.
+     */
+    public function test_mid_sheet_header_style_change_does_not_rewrite_pending_header(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth(sample: 100);
+        $writer->setHeaderStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF']);
+        $writer->startFile(['a', 'b']);
+        $writer->writeRow([1, 'x']);
+        $writer->writeRow([2, 'y']);
+
+        $writer->setHeaderStyle(['fill' => '#7030A0', 'color' => '#FFFFFF']); // mid-sheet
+
+        $writer->writeRow([3, 'z']);
+        $writer->writeRow([4, 'w']);
+        $writer->newSheet('S2');
+        $writer->writeRow([5, 'v']);
+        $writer->finishFile();
+
+        $this->assertNotSame(
+            $this->headerStyleIdOf(1),
+            $this->headerStyleIdOf(2),
+            'mid-sheet setHeaderStyle must not repaint the sheet whose sample was pending'
+        );
+
+        // 4 data rows + header all landed on sheet 1.
+        $this->assertSame(5, preg_match_all('/<row /', $this->sheetXml(1)));
+    }
+
+    /**
+     * FIX B: builtin numFmt ids participate in the heuristic minimum-
+     * width table — date/datetime/currency columns stop rendering as
+     * ###### — while the cell bytes stay byte-identical to the pre-fix
+     * writer (the literal below was captured from the pre-fix build;
+     * only the <cols> hints may differ).
+     */
+    public function test_builtin_numfmt_ids_get_min_width_in_heuristic_mode(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth(); // heuristic
+        $writer->setColumnFormat(1, W::BUILTIN_NUMFMT_DATE);
+        $writer->setColumnFormat(2, W::BUILTIN_NUMFMT_DATETIME);
+        $writer->setColumnFormat(3, W::BUILTIN_NUMFMT_CURRENCY);
+        $writer->startFile(['d', 'dt', 'c']);
+        $writer->writeRow([
+            new \DateTimeImmutable('2026-01-15 10:30:00'),
+            new \DateTimeImmutable('2026-01-15 10:30:00'),
+            1234.56,
+        ]);
+        $writer->finishFile();
+
+        $xml = $this->sheetXml(1);
+
+        $this->assertStringContainsString('<col min="1" max="1" width="12"', $xml); // date
+        $this->assertStringContainsString('<col min="2" max="2" width="20"', $xml); // datetime
+        $this->assertStringContainsString('<col min="3" max="3" width="14"', $xml); // currency
+
+        // Cell bytes pinned to the pre-fix writer output.
+        $this->assertStringContainsString(
+            '<row r="2"><c r="A2" s="2" t="n"><v>46037.4375</v></c>'
+            .'<c r="B2" s="3" t="n"><v>46037.4375</v></c>'
+            .'<c r="C2" s="4" t="n"><v>1234.56</v></c></row>',
+            $xml
+        );
+    }
+
+    /**
+     * Named presets keep their existing minimums (regression guard for
+     * the shared table) and unformatted columns stay on the header
+     * heuristic.
+     */
+    public function test_named_presets_and_plain_columns_unchanged(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->setAutoColumnWidth();
+        $writer->setColumnFormat(1, 'date');
+        $writer->startFile(['d', 'plain']);
+        $writer->writeRow([new \DateTimeImmutable('2026-01-15'), 'x']);
+        $writer->finishFile();
+
+        $xml = $this->sheetXml(1);
+        $this->assertStringContainsString('<col min="1" max="1" width="12"', $xml);
+        $this->assertStringContainsString('<col min="2" max="2" width="8"', $xml);
+    }
+
+    private function sheetXml(int $sheet): string
+    {
+        $zip = new \ZipArchive();
+        $zip->open($this->testFile);
+        $xml = (string) $zip->getFromName("xl/worksheets/sheet{$sheet}.xml");
+        $zip->close();
+
+        return $xml;
+    }
+
+    /** s= attribute of the sheet's A1 header cell, or null. */
+    private function headerStyleIdOf(int $sheet): ?string
+    {
+        if (preg_match('/<c r="A1" s="(\d+)"/', $this->sheetXml($sheet), $m)) {
+            return $m[1];
+        }
+
+        return null;
+    }
+}

--- a/tests/Writers/ConfigDefaultsTest.php
+++ b/tests/Writers/ConfigDefaultsTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Sinks\S3MultipartSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\BaseXlsxWriter;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * v3.2.2 config semantics: the published config/xlsx-stream.php is
+ * applied at writer construction — version-gated so pre-3.2.2
+ * published copies (whose keys were never read and whose stale values
+ * contradict the code defaults) stay inert, and always overridable by
+ * code-level setters.
+ *
+ * The probe subclass exposes the protected fold + the resulting state;
+ * no global config() shim is defined (the suite runs under Testbench,
+ * whose real config() the constructor path already exercises).
+ */
+class ConfigDefaultsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Neutralize the package's own published config (merged by the
+        // service provider) so every probe starts from the pure code
+        // defaults and each scenario feeds applyConfigDefaults()
+        // exactly the array it means to test.
+        config(['xlsx-stream' => []]);
+    }
+
+    private function probe(): ConfigProbeWriter
+    {
+        return new ConfigProbeWriter;
+    }
+
+    public function test_missing_version_key_keeps_code_defaults(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['writer' => ['compression_level' => 9, 'buffer_flush_interval' => 5]]);
+
+        $this->assertSame(5, $w->deflateLevel());
+        $this->assertSame(1000, $w->bufferFlushInterval());
+    }
+
+    public function test_version_1_config_is_ignored(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['version' => 1, 'writer' => ['compression_level' => 9]]);
+
+        $this->assertSame(5, $w->deflateLevel());
+    }
+
+    public function test_version_2_compression_level_applies(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['version' => 2, 'writer' => ['compression_level' => 7]]);
+
+        $this->assertSame(7, $w->deflateLevel());
+    }
+
+    public function test_setter_overrides_config(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['version' => 2, 'writer' => ['compression_level' => 7]]);
+        $w->setCompressionLevel(3);
+
+        $this->assertSame(3, $w->deflateLevel());
+    }
+
+    public function test_invalid_values_are_silently_ignored(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['version' => 2, 'writer' => [
+            'compression_level' => 0,          // out of range
+            'buffer_flush_interval' => 'abc',  // not numeric
+        ]]);
+
+        $this->assertSame(5, $w->deflateLevel());
+        $this->assertSame(1000, $w->bufferFlushInterval());
+
+        $w->applyConfig(['version' => 2, 'writer' => ['compression_level' => 'abc']]);
+        $this->assertSame(5, $w->deflateLevel());
+    }
+
+    public function test_buffer_flush_interval_applies(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(['version' => 2, 'writer' => ['buffer_flush_interval' => 5000]]);
+
+        $this->assertSame(5000, $w->bufferFlushInterval());
+    }
+
+    public function test_null_config_is_a_no_op(): void
+    {
+        $w = $this->probe();
+        $w->applyConfig(null);
+
+        $this->assertSame(5, $w->deflateLevel());
+        $this->assertSame(1000, $w->bufferFlushInterval());
+    }
+
+    public function test_constructor_applies_live_laravel_config(): void
+    {
+        config(['xlsx-stream' => ['version' => 2, 'writer' => ['compression_level' => 8]]]);
+
+        $this->assertSame(8, $this->probe()->deflateLevel());
+    }
+
+    public function test_constructor_ignores_pre_322_shaped_config(): void
+    {
+        // The exact shape a pre-3.2.2 published copy has: no version
+        // key, stale level 1. Must stay as inert as it always was.
+        config(['xlsx-stream' => ['writer' => ['compression_level' => 1]]]);
+
+        $this->assertSame(5, $this->probe()->deflateLevel());
+    }
+
+    // ------------------------------------------------------------------
+    // forDisk() part-size resolution (pure helper — no S3 client needed)
+    // ------------------------------------------------------------------
+
+    private function resolvePartSize(?int $explicit, ?array $config): int
+    {
+        $m = new \ReflectionMethod(SinkableXlsxWriter::class, 'resolvePartSize');
+
+        return $m->invoke(null, $explicit, $config);
+    }
+
+    public function test_part_size_explicit_argument_wins(): void
+    {
+        $this->assertSame(
+            16 * 1024 * 1024,
+            $this->resolvePartSize(16 * 1024 * 1024, ['version' => 2, 's3' => ['part_size' => 5242880]])
+        );
+    }
+
+    public function test_part_size_from_version_2_config(): void
+    {
+        $this->assertSame(
+            33554432,
+            $this->resolvePartSize(null, ['version' => 2, 's3' => ['part_size' => 33554432]])
+        );
+    }
+
+    public function test_part_size_ignores_unversioned_config(): void
+    {
+        $this->assertSame(
+            S3MultipartSink::DEFAULT_PART_SIZE,
+            $this->resolvePartSize(null, ['s3' => ['part_size' => 33554432]])
+        );
+    }
+
+    public function test_part_size_defaults_without_config(): void
+    {
+        $this->assertSame(S3MultipartSink::DEFAULT_PART_SIZE, $this->resolvePartSize(null, null));
+        $this->assertSame(
+            S3MultipartSink::DEFAULT_PART_SIZE,
+            $this->resolvePartSize(null, ['version' => 2, 's3' => ['part_size' => 'abc']])
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // forDisk() concurrency resolution (pure helper — no S3 client needed)
+    // ------------------------------------------------------------------
+
+    private function resolveConcurrency(?array $config): int
+    {
+        $m = new \ReflectionMethod(SinkableXlsxWriter::class, 'resolveConcurrency');
+
+        return $m->invoke(null, $config);
+    }
+
+    public function test_concurrency_defaults_without_version_key(): void
+    {
+        $this->assertSame(
+            S3MultipartSink::DEFAULT_CONCURRENCY,
+            $this->resolveConcurrency(['s3' => ['concurrency' => 8]])
+        );
+        $this->assertSame(S3MultipartSink::DEFAULT_CONCURRENCY, $this->resolveConcurrency(null));
+    }
+
+    public function test_concurrency_from_version_2_config(): void
+    {
+        $this->assertSame(8, $this->resolveConcurrency(['version' => 2, 's3' => ['concurrency' => 8]]));
+    }
+
+    public function test_concurrency_ignores_invalid_values(): void
+    {
+        foreach ([0, -1, 'x'] as $invalid) {
+            $this->assertSame(
+                S3MultipartSink::DEFAULT_CONCURRENCY,
+                $this->resolveConcurrency(['version' => 2, 's3' => ['concurrency' => $invalid]]),
+                'invalid value: '.var_export($invalid, true)
+            );
+        }
+    }
+
+    public function test_concurrency_ignores_version_1_config(): void
+    {
+        $this->assertSame(
+            S3MultipartSink::DEFAULT_CONCURRENCY,
+            $this->resolveConcurrency(['version' => 1, 's3' => ['concurrency' => 8]])
+        );
+    }
+}
+
+/**
+ * Minimal concrete writer: no-op destination, protected state exposed.
+ */
+class ConfigProbeWriter extends BaseXlsxWriter
+{
+    protected function writeToDest(string $data): void
+    {
+        // discard — construction/config behaviour is all these tests need
+    }
+
+    public function applyConfig(?array $config): void
+    {
+        $this->applyConfigDefaults($config);
+    }
+
+    public function deflateLevel(): int
+    {
+        return $this->deflateLevel;
+    }
+
+    public function bufferFlushInterval(): int
+    {
+        return $this->bufferFlushInterval;
+    }
+}


### PR DESCRIPTION
## What

Correctness patch, two fixes. No new public API; the writer's output
path is untouched (its bytes are the 3.2.1 bytes).

### 1. Auto-split workbooks now answer queries for the WHOLE table

When an export exceeds Excel's 1,048,576-row ceiling the writer splits
it across continuation sheets — but every query API silently answered
from the active sheet alone. On a 2.1M-row file `rowCount()` said
1,048,575, `findRow()` returned null past sheet 1, `columnStats()`
summed less than half the data.

Fix: the reader detects continuation chains (consecutive **exactly
full** sheets with **identical headers** on born-indexed files) and
queries them as ONE logical table with continuous global row numbers.
Spanned surface: `rowCount / rows / chunked / rowAt / rowRange /
rowsWhere / findRow / columnStats / groupStats / quantile / median /
countDistinct / shards`. Aggregates fold per-sheet block stats and
merge t-digest/HLL sketches, with an all-or-nothing rule — `null` over
a silent partial answer. Intentional multi-sheet workbooks (different
headers, non-full sheets) and single-sheet files keep their exact
previous behaviour.

### 2. The published config now actually applies (versioned)

`config/xlsx-stream.php` shipped keys (`XLSX_STREAM_COMPRESSION_LEVEL`
etc.) that no code ever read. They now apply at writer construction,
behind a `'version' => 2` gate: pre-3.2.2 published copies lack the key
and stay inert, so their stale defaults (level 1 vs the code's 5)
cannot silently change existing output. Precedence: setters > config >
package defaults; invalid values are ignored. Applied keys:
`writer.compression_level`, `writer.buffer_flush_interval`,
`s3.part_size`, `s3.concurrency`. Keys with no implementation behind
them (`logging`, `memory`, `max_rows_per_sheet`) are gone; SDK-owned
retry settings are documented as `S3Client` config.

## How it was verified

- **Repro-first:** the span test suite was written RED against 3.2.1
  (11 failures reproducing the bug), then turned green by the fix —
  14/14, plus two negative controls pinning that intentional
  multi-sheet workbooks do NOT chain.
- **Full suite:** 526 tests / 6975 assertions, PHPStan clean, Pint
  clean (repo-wide).
- **Speed gate (A/B vs the v3.2.1 tag, five-run medians):** every
  single-sheet read path within ±1 % (noise); non-chain multi-sheet
  workbooks at 0.00 % — chain detection costs nothing unless a chain
  exists. Span queries on a 2.1M-row 3-sheet chain: `findRow` 9.5 ms,
  `rowAt` 2.2 ms, `columnStats` 1.5 ms, 6 MB peak RAM.
- `git diff v3.2.1 -- src/` touches exactly three files: the reader
  (span fix), and the two writer files' construction-time config
  wiring — zero changes on any row-writing path.