### PR TITLE
V3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ A backward-compatible minor: a real query engine on top of the born-indexed
 sidecar, writer & DX ergonomics, integrity verification, and a critical S3
 write-memory fix. No breaking API changes — the base `Source` contract is
 unchanged and classic writer output stays byte-identical (compact mode and
-group-aligned blocks are opt-in). Full suite 599 tests / 7481 assertions;
+group-aligned blocks are opt-in). Full suite 604 tests / 7541 assertions;
 local write/read and the whole query surface measured at parity with 3.2.x
 (no hot-path regression).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,96 @@ All notable changes to `kolay/xlsx-stream` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] — 2026-07-06
+
+A backward-compatible minor: a real query engine on top of the born-indexed
+sidecar, writer & DX ergonomics, integrity verification, and a critical S3
+write-memory fix. No breaking API changes — the base `Source` contract is
+unchanged and classic writer output stays byte-identical (compact mode and
+group-aligned blocks are opt-in). Full suite 599 tests / 7481 assertions;
+local write/read and the whole query surface measured at parity with 3.2.x
+(no hot-path regression).
+
+### Added — query engine
+
+- **`rowsWhereAll(array $predicates)`** — multi-predicate AND with zone-map
+  INTERSECTION. A row matching every predicate lives in a block surviving
+  every predicate, so querying two differently-clustered columns reads far
+  fewer blocks than either alone. Untracked columns filter per row.
+- **`estimatedRows(col, op, value, value2?)` + `explain(array $predicates)`**
+  — zero-I/O selectivity and query plans from the sidecar alone.
+  `estimatedRows` returns a hard zone-map `upper` bound plus a t-digest/HLL
+  `estimate`; `explain` returns `{strategy, candidateBlocks, runs,
+  estimatedRows, estimatedBytes}` — the byte budget a pruned scan would fetch.
+- **`topRows(col, k, desc)`** — "ORDER BY column [DESC] LIMIT k" from the
+  sidecar. On a sorted column the k extremes are read from one end (one seek,
+  early exit — an indexed top-N); on an unsorted column a single scan holds
+  an O(k) heap.
+- **`sampleRows(k, seed?)`** — a uniform random sample of k rows fetched via
+  the index (≈k block reads, not a full scan). Seeded for reproducibility;
+  unbiasedness proven by a chi-square goodness-of-fit gate.
+- **Column addressing by header name** across the whole query surface —
+  `columnStats('amount')`, `rowsWhere('date', …)`, `groupStats('region',
+  'total')`, etc. Index addressing keeps its exact fast path.
+- **`Readers\Bucket::year()/month()/day()`** — ready-made monotone bucket
+  callables for `groupStats()` over a date column ("GROUP BY month" in one
+  call), so the group-pure block pushdown still applies.
+- **`verify()`** — read-side integrity check against the writer's per-block
+  running-CRC (SCRC) pins and whole-sheet CRC. A single inflate pass at O(1)
+  memory reports which block (if any) went bad — the "verified read" for
+  audit/payroll/HR data. Falls back to the whole-entry ZIP CRC without a
+  sidecar.
+- **`onFullScan(callable)`** — observability hook fired when a query cannot
+  push down and degrades to a full scan (unindexed column, unsorted groupBy),
+  with `{query, column, reason, entry}` context.
+
+### Added — writer & S3
+
+- **`queryable(array $columns, every?, withSketches?)`** — one call that
+  turns on the random-access index + zone maps + sketches for a set of
+  columns; byte-identical to chaining the three explicit calls.
+- **`compact()`** — opt-in r-less cell output (ECMA-376 makes `c/@r` and
+  `row/@r` optional). Compressed sheets shrink ~52–62 %, and both writing and
+  reading get faster (smaller XML to build and tokenize). The compact row
+  builders are the exact r-less projection of the classic ones (byte-oracle
+  test); classic output is byte-identical when off. Opens in Excel/
+  LibreOffice/Numbers; read by PhpSpreadsheet 5.8 & OpenSpout 4.28.
+- **`syncAtGroupBoundaries(column)`** — align index block boundaries to a
+  column's group changes so every block holds one group; `groupStats()` then
+  folds each block straight from the sidecar and reads only the header block.
+  Enables the index if not already on; default off → output byte-identical.
+- **Opt-in per-part integrity: `new S3MultipartSink(..., verifyParts: true)`**
+  — attaches a `Content-MD5` to every part so S3 verifies it and rejects a
+  corrupted part; a bad byte never enters the object ("verified export").
+- **Bounded ranged reads (`Contracts\SupportsBoundedStream`)** — a pruned
+  scan that stops at a sync boundary fetches only that block run's bytes; on
+  S3 an open-ended `[offset, EOF]` GET becomes an exact ranged read. Optional
+  gap-bridging keeps one ranged read alive across a short gap of non-matching
+  blocks when transferring those bytes beats a round-trip (via an optional
+  `Contracts\ProvidesCostHints` on the Source).
+
+### Fixed
+
+- **S3 multipart writes now use O(1) memory (was O(file size)).** The
+  parallel (async) upload path leaked: the AWS SDK's promise/command graph
+  held each dispatched part's body in a reference cycle refcounting cannot
+  free, so write memory climbed with row count (~130 MB at 3M rows, ≈ the
+  whole file — unbounded beyond), silently breaking the streaming-to-S3
+  memory promise. Uploads are now **synchronous by default** and release
+  each part as it lands, keeping memory flat at ~part size regardless of
+  file size (verified ~30 MB peak on a 3M-row write). Local writes were
+  always flat.
+
+### Changed
+
+- **`S3MultipartSink` default `concurrency` is now 1 (was 4).** This is the
+  memory fix above: the default is strictly synchronous uploads (O(1) memory,
+  steady throughput — no faster on bandwidth-bound links, and free of the
+  leak). Parallel part uploads remain available as an opt-in (`concurrency >
+  1` / `XLSX_STREAM_S3_CONCURRENCY`), now with per-part GC to bound their
+  footprint — prefer them only where you have measured a win on a high-latency
+  link. See UPGRADE.md.
+
 ## [3.2.2] — 2026-07-05
 
 Correctness patch. No new public API. Row/cell bytes are unchanged

--- a/README.md
+++ b/README.md
@@ -284,13 +284,19 @@ $s3Client = new S3Client([
     ],
 ]);
 
-// Create S3 sink with 32MB parts
+// Create S3 sink (default 8 MB parts, synchronous uploads = O(1) memory)
 $sink = new S3MultipartSink(
     $s3Client,
     'my-bucket',
-    'exports/report.xlsx',
-    32 * 1024 * 1024 // 32MB parts for optimal performance
+    'exports/report.xlsx'
 );
+
+// On a HIGH-LATENCY link (cross-region, slow uplink) you can opt into a
+// parallel upload window — it overlaps per-part round-trips at the cost of
+// a higher (sawtooth) memory profile. On bandwidth-bound links it's no
+// faster, so measure before flipping it on:
+//   new S3MultipartSink($s3Client, 'my-bucket', 'key.xlsx', concurrency: 4);
+// (or set XLSX_STREAM_S3_CONCURRENCY=4 for forDisk() writers.)
 
 $writer = new SinkableXlsxWriter($sink);
 
@@ -300,7 +306,7 @@ $writer->setCompressionLevel(1)      // Fastest compression
 
 $writer->startFile(['ID', 'Name', 'Email', 'Status']);
 
-// Stream millions of rows with constant 32MB memory
+// Stream millions of rows with flat ~part-size memory (default ~8 MB)
 User::query()
     ->select(['id', 'name', 'email', 'status'])
     ->chunkById(1000, function ($users) use ($writer) {
@@ -1031,7 +1037,9 @@ return [
     ],
     's3' => [
         'part_size' => env('XLSX_STREAM_S3_PART_SIZE', 8 * 1024 * 1024),
-        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 4),
+        // 1 = synchronous uploads, O(1) memory (default). Raise to opt into
+        // parallel part uploads (higher, sawtooth memory) — see UPGRADE.md.
+        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 1),
     ],
 ];
 ```
@@ -1045,8 +1053,10 @@ $writer->withRandomAccessIndex(every: 10000)
        ->withColumnSketches([1, 4]);
 $writer->onProgress(fn ($rows, $bytes) => ...)->setProgressInterval(10000);
 
-// Full control: construct the sink directly.
-new S3MultipartSink($s3, $bucket, $key, partSize: 8 * 1024 * 1024, concurrency: 8);
+// Full control: construct the sink directly. concurrency defaults to 1
+// (synchronous, O(1) memory); raise it only for high-latency links where
+// you've measured a win — parallel uploads hold more (sawtooth) memory.
+new S3MultipartSink($s3, $bucket, $key, partSize: 8 * 1024 * 1024, concurrency: 4);
 ```
 
 Transient S3 retries belong to the AWS SDK — configure them on your
@@ -1089,7 +1099,8 @@ callback: wire it to your logger of choice.
 
 4. **S3 Multipart Upload**
    - Direct streaming to S3 using multipart upload
-   - 32MB parts uploaded as they're ready
+   - Default 8 MB parts, uploaded synchronously and released as they land
+     (O(1) memory); parallel uploads are opt-in
    - No local file required at any point
 
 
@@ -1097,12 +1108,15 @@ callback: wire it to your logger of choice.
 
 - **Local writes are O(1)**: a row buffer (default 10K rows) plus the
   deflate context — ~6 MB peak regardless of row count.
-- **S3 writes are bounded by the upload window** *(v3.2)*: peak ≈
-  `part_size × (concurrency + 2)` — ~46 MB flat at the defaults, at 1M
-  rows and at 10M rows alike. (Before v3.2 the sink's buffer copies
-  ratcheted ~40 MB per million rows; the parallel window rework removed
-  that.) Memory saw-tooths as parts fill and upload — that's the buffer
-  cycle, not a leak.
+- **S3 writes are O(1)** *(v3.3)*: the default synchronous sink
+  (`concurrency: 1`) holds ~`part_size` (one part buffer + the part being
+  uploaded), flat at 1M rows and at 10M rows alike — measured ~30 MB peak
+  on a 3M-row write. The optional parallel upload window (`concurrency >
+  1`) trades that for latency-hiding on high-RTT links; it holds more
+  (a higher sawtooth) and runs a per-part GC to bound it. (Through v3.2
+  the parallel window was the default and its memory grew with the file —
+  the AWS SDK's async promise graph retained each part's body; v3.3's
+  synchronous default fixes that.)
 - **Reads are bounded by construction**: inflate chunks + one row in
   flight — ~6 MB for files this package wrote (24 MB ceiling with large
   external shared-strings tables, which now parse streaming — the full
@@ -1124,16 +1138,17 @@ File Size: 178 MB compressed XLSX
 Sheets: 5 (automatic splitting at Excel limit)
 Total Time: 96.85 seconds
 Average Speed: 46,462 rows/second
-Memory Usage: 178 MB average with ±178 MB fluctuation
-Peak Memory: 356 MB (during S3 part upload)
+Peak Memory: ~30 MB, flat (v3.3 synchronous S3 writes — O(1) regardless
+             of row count; the pre-v3.3 parallel-window default peaked at
+             ~356 MB here as the SDK retained each part's body)
 ```
 
 
-### Key Performance Metrics *(v3.2)*
+### Key Performance Metrics *(v3.3)*
 
 - **Write — Local**: ~289K rows/s sustained, 6 MB peak
-- **Write — S3**: network-bound; +36% over v3.0.2 same-link, steady
-  wall times under the parallel window, ~46 MB flat peak
+- **Write — S3**: network-bound; +36% over v3.0.2 same-link; O(1) memory
+  (synchronous default, ~30 MB flat peak regardless of file size)
 - **Read — Local**: ~127K rows/s full scan, bounded memory at any size
 - **Point reads**: `rowAt` ~1.1 ms within a block; `rows(skip: 1M)` 2.5 ms
 - **Analytics**: `median`/`quantile`/`countDistinct` answer with zero

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ median, p99 or distinct count **without reading a single row** — over
 HTTP range requests, from a file Excel opens like any other.
 
 - **Write**: ~289K rows/s locally at 6 MB peak RAM; direct S3 multipart
-  (parallel upload window, no temp files)
+  streaming at bounded memory — synchronous by default (flat ~part-size
+  working set, true O(1) regardless of file size), optional parallel
+  upload window, no temp files
 - **Read**: ~127K rows/s full scans with bounded memory, any file size
 - **Seek**: `rowAt(1_000_000)` in milliseconds via the born-indexed sidecar
 - **Query**: `columnStats` / `rowsWhere` / `findRow` / `groupStats` with
@@ -51,8 +53,12 @@ Numbers, PhpSpreadsheet and OpenSpout all open the files normally.
 Absolute S3 throughput tracks the network path far more than the
 library (the same 1M-row export measured 59K–153K rows/s across
 sessions) — the honest S3 claim is the same-day A/B: **v3.2's writer is
-+36% over v3.0.2 on an identical link**, and the parallel upload window
-turns 3× wall-time swings into steady runs. Benchmark on your own link.
++36% over v3.0.2 on an identical link**. Uploads are **synchronous by
+default** — part memory stays flat at ~part-size no matter how large the
+file, and throughput is steady; a **parallel upload window is opt-in**
+(`concurrency`) for high-latency links where hiding per-request
+round-trips outweighs its higher (sawtooth) memory. Benchmark on your
+own link.
 
 ### Cross-package, 100K rows (May 2026, latest stables)
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ Numbers, PhpSpreadsheet and OpenSpout all open the files normally.
 
 ### The trajectory — same canonical workloads, every release
 
-| | v1.x (Sep 2025) | v2.2 (May 2026) | v3.0 (May 2026) | v3.1 (Jul 2026) | v3.2 (Jul 2026) |
-|---|---|---|---|---|---|
-| Write, local | ~182K rows/s | ~210K | ~215K | **~289K** | ~289K |
-| Write, S3 (1M rows) | ~9K rows/s | ~107K | ~107K | +36% same-link A/B | + parallel window |
-| Read, local | — | — | ~70K rows/s | ~106K | **~127K** |
-| Random access | — | — | O(1) `rowAt` | + block-pruned queries | + within-block skip (~19×) |
-| Analytics | — | — | — | `columnStats` 0-request | **median/p99/distinct 0-request** |
-| Peak RAM (write/read) | 0-2 MB / — | ~6 MB / — | 6 / 24 MB | 6 / 24 MB | 6 / **6 MB** |
+| | v1.x (Sep 2025) | v2.2 (May 2026) | v3.0 (May 2026) | v3.1 (Jul 2026) | v3.2 (Jul 2026) | v3.3 (Jul 2026) |
+|---|---|---|---|---|---|---|
+| Write, local | ~182K rows/s | ~210K | ~215K | **~289K** | ~289K | ~289K |
+| Write, S3 | ~9K rows/s | ~107K | ~107K | +36% same-link A/B | + parallel window | **O(1) memory (was O(file))** |
+| Read, local | — | — | ~70K rows/s | ~106K | **~127K** | ~127K |
+| Random access | — | — | O(1) `rowAt` | + block-pruned queries | + within-block skip (~19×) | + bounded ranged fetch |
+| Query engine | — | — | — | `columnStats`/`rowsWhere` | + `groupStats` | **AND / `topRows` / `explain` / by-name** |
+| Analytics | — | — | — | 0-request sums | median/p99/distinct 0-request | + `Bucket::month` GROUP BY |
+| Integrity | — | — | — | — | — | **`verify()` + S3 per-part checks** |
+| Peak RAM (write/read) | 0-2 MB / — | ~6 MB / — | 6 / 24 MB | 6 / 24 MB | 6 / **6 MB** | 6 / 6 MB |
 
 Absolute S3 throughput tracks the network path far more than the
 library (the same 1M-row export measured 59K–153K rows/s across
@@ -538,6 +540,77 @@ merge associatively, which is what future segment/partition stitching
 builds on. The full binary layout is public: **KXSI is an open spec**
 (see [SPEC.md](SPEC.md)) with committed conformance vectors under
 `tests/SpecVectors/`, so other implementations can verify byte-for-byte.
+
+### The query engine grows up *(v3.3+)*
+
+The sidecar turns into a small SQL-shaped engine — all answered by
+reading only the blocks that can match, and all addressable by header
+name (not just 1-based index):
+
+```php
+// One call makes an export fully queryable (index + zone maps + sketches):
+$writer->queryable([1, 3, 4]);                 // writer side, before startFile()
+
+// Multi-predicate AND — intersects each predicate's surviving blocks, so
+// two differently-clustered columns read far fewer blocks than either alone:
+$reader->rowsWhereAll([
+    ['region', '=', 3],
+    ['amount', 'between', 500, 5000],
+]);
+
+// ORDER BY amount DESC LIMIT 10 — on a sorted column, one seek + early exit:
+$reader->topRows('amount', 10, desc: true);
+
+// Plan a query WITHOUT running it — zero I/O, straight from the sidecar:
+$reader->estimatedRows('amount', '>=', 1000);  // ['upper' => .., 'estimate' => ..]
+$reader->explain([['region', '=', 3], ['amount', '>=', 500]]);
+//   ['strategy' => 'zone-map-prune', 'candidateBlocks' => .., 'runs' => ..,
+//    'estimatedRows' => [...], 'estimatedBytes' => ..]   // the S3 range budget
+
+// GROUP BY month over a date column — Bucket:: helpers keep the pushdown:
+use Kolay\XlsxStream\Readers\Bucket;
+$reader->groupStats('order_date', 'total', Bucket::month());   // one row per YYYYMM
+
+// A uniform, reproducible random sample without a full scan (≈k block reads):
+$reader->sampleRows(1000, seed: 42);
+
+// Know when a query silently falls back to a full scan (no index for it):
+$reader->onFullScan(fn (array $ctx) => logger()->warning('full scan', $ctx));
+```
+
+### Integrity — verified reads & writes *(v3.3+)*
+
+For data that matters (payroll, HR, audit exports):
+
+```php
+// Read side: check every block against the CRC the writer pinned at each
+// sync point. One inflate pass, O(1) memory; names the block that went bad.
+$report = $reader->verify();
+// ['ok' => true, 'sheets' => [['ok' => true, 'corrupt_blocks' => [], ...]]]
+
+// Write side: S3 verifies each part's Content-MD5 and rejects a corrupted
+// one — a bad byte never enters the object.
+$sink = new S3MultipartSink($s3, $bucket, $key, verifyParts: true);
+```
+
+### Bigger, cheaper writes *(v3.3+)*
+
+```php
+// Compact output: drop the optional r attributes on cells/rows (ECMA-376
+// allows it). ~52–62% smaller compressed sheets; opens in Excel/LibreOffice/
+// Numbers. Classic output is byte-identical when off.
+$writer->compact();
+
+// Group-aligned blocks: align index blocks to a sorted group column so
+// groupStats() folds each block from the sidecar — zero row reads.
+$writer->syncAtGroupBoundaries(2);
+```
+
+> **S3 writes are now O(1) memory.** Multipart uploads default to
+> synchronous (`concurrency: 1`): part memory stays flat at ~part-size no
+> matter the file size. (Earlier versions defaulted to a parallel window
+> that could grow memory toward the whole file.) Parallel is still an opt-in
+> for high-latency links — see [UPGRADE.md](UPGRADE.md).
 
 ### Parallel reads — shard a sheet across queue workers *(v3.1+)*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ listed below `Backlog` is "considered, not committed".
 
 | Version | Date | Highlights |
 |---|---|---|
+| [3.3.0](CHANGELOG.md#330--2026-07-06) | 2026-07-06 | The query engine grows up + integrity + O(1) S3 writes. **Query:** `rowsWhereAll()` (multi-predicate AND via zone-map intersection), `estimatedRows()`/`explain()` (zero-I/O plans), `topRows()` (indexed ORDER BY … LIMIT), `sampleRows()` (seeded uniform sample), column addressing by header name, `Bucket::month/day/year` for `groupStats`, bounded ranged reads + gap-bridging. **Writer/DX:** `queryable()` one-call preset, opt-in `compact()` (r-less cells, ~52–62% smaller sheets), `syncAtGroupBoundaries()` (zero-scan `groupStats`), `onFullScan()` hook. **Integrity:** `verify()` (block-granularity CRC report), opt-in per-part `Content-MD5` so S3 rejects a corrupted part. **Fixed:** S3 multipart writes are now O(1) memory (was O(file size)) — default `concurrency` 1, parallel opt-in. No breaking changes (base `Source` contract stable; classic output byte-identical) |
 | [3.2.2](CHANGELOG.md#322--2026-07-05) | 2026-07-05 | Correctness patch: on auto-split workbooks (>1,048,575 rows) the entire query surface — `rowCount`/`rows`/`rowAt`/`rowRange`/`rowsWhere`/`findRow`/`columnStats`/`groupStats`/`quantile`/`countDistinct`/`shards` — now spans the continuation chain as one logical table instead of silently answering from the active sheet alone; misleading never-read config keys removed |
 | [3.2.0](CHANGELOG.md#320--2026-07-04) | 2026-07-04 | KXSI becomes an **open specification** ([SPEC.md](SPEC.md)) with a byte-pinned conformance suite; `SCRC` per-sync-point integrity CRCs; approximate analytics — `withColumnSketches()` embeds t-digest + HyperLogLog, `quantile()`/`median()`/`countDistinct()` answer with zero row reads; `groupStats()` sorted-group pushdown; +30 % read throughput (tokenizer micro-pass); `rows(skip)` fast path (~1,580× indexed) + within-block fast-forward (~19×); parallel S3 multipart upload (flat memory, steady wall times); packed shared strings (ceiling 20 → 64 MB compressed at 3.5× less peak); `autoDetectDates()` for external files |
 | [3.1.0](CHANGELOG.md#310--2026-07-04) | 2026-07-04 | Queryable XLSX: KXSI TLV sidecar extension with per-block column stats (zone maps) — `withColumnStats()` on the writer; `columnStats()`/`rowsWhere()`/`findRow()` on the reader (Parquet-style block pruning, sidecar-only aggregates, single-block point lookups); `shards()`/`rowsForShard()` for zero-coordination queue fan-out; writer +55 % throughput (PCRE-JIT escape gate, flattened row builder, level-5 default); S3 reader open 7 → 3 round trips; `rowCount()` boundary-count fast path |
@@ -19,10 +20,14 @@ listed below `Backlog` is "considered, not committed".
 | [2.0.1](CHANGELOG.md#201--2026-05-03) | 2026-05-03 | CI / lint cleanup |
 | [2.0.0](CHANGELOG.md#200--2026-05-03) | 2026-05-03 | DateTime support, native boolean cells, big-int preservation, state machine guards, modernized dependency matrix |
 
-## Next: v3.3 — Durable exports & smarter S3 reads
+## Next: v3.4 — Resumable exports & tail-latency I/O
 
-Additive, no breaking changes planned. The through-line: exports that
-survive crashes, and reads that plan their own I/O.
+Additive, no breaking changes planned. v3.3 shipped the smarter-reads
+half of the original "durable + smart S3" theme (the query engine,
+`explain()`/`estimatedRows()`, `rowsWhereAll()`, range-coalescing via
+gap-bridging, and integrity `verify()`). v3.4 is the **durable** half:
+exports that survive a crash, plus the tail-latency I/O work deferred
+from v3.3.
 
 ### Resumable S3 exports (the headline)
 
@@ -34,26 +39,20 @@ concatenation) are already PoC-proven.
 
 ### Reader I/O planning
 
-- **Range coalescing with a cost model** — when a pruned query wants
-  blocks {17, 19, 20}, decide between three requests or one padded
-  request from measured RTT/bandwidth (S3 `GetObject` accepts only a
-  single range per request).
-- **`explain()` / `estimatedRows()`** — return the query plan without
-  executing: strategy, candidate blocks, estimated requests/bytes, and
-  a zero-I/O result-size estimate (zone-map counts give a hard upper
-  bound; the t-digest CDF gives a point estimate). Doubles as a CI
-  oracle (plan vs. actual request count).
-- **`rowsWhereAll()`** — multi-predicate queries whose per-column
-  zone-map survivor sets are intersected before any block is read
-  (`WHERE date BETWEEN … AND amount > …` scans the intersection, never
-  more blocks than the most selective predicate alone).
+Shipped in v3.3 ✅: **range coalescing** (gap-bridging with a cost model
+via `Contracts\ProvidesCostHints` — keep one ranged read alive across a
+short gap when it beats a round-trip), **`explain()`/`estimatedRows()`**
+(zero-I/O plans + hard upper bound + t-digest point estimate),
+**`rowsWhereAll()`** (multi-predicate zone-map intersection). Still ahead:
+
 - **Hedged range requests** — re-issue a slow critical-path range on a
   second connection, first response wins; insurance against S3 tail
   latency on point lookups.
 - **Prefetch pipeline** — keep 3-4 blocks in flight during sequential
   S3 scans so inflate/parse overlaps fetch.
 - **`onProgress` callback for the reader** — symmetric to the writer's,
-  for ingestion dashboards.
+  for ingestion dashboards. (The reader already has `onFullScan()` for
+  pushdown observability as of v3.3.)
 
 ### Tooling
 
@@ -74,7 +73,7 @@ concatenation) are already PoC-proven.
   the first `write()` so the sink is cheap to instantiate in DI
   contexts.
 
-### Queryable-XLSX follow-ups (PoC-verified, sequenced after v3.3)
+### Queryable-XLSX follow-ups (PoC-verified, sequenced after v3.4)
 
 - **Appendable XLSX** — end the last sheet at a full-flush boundary,
   reopen and continue with a fresh deflate context; on S3,
@@ -88,10 +87,10 @@ concatenation) are already PoC-proven.
 - **Verified partial reads (`MRKL`)** — a Merkle tree over per-block
   hashes (tag reserved in SPEC.md): prove a ranged read belongs to a
   signed file without fetching the rest of it.
-- **Compact cell refs** (`c/@r` omitted, spec-legal) — measured 2.1×
-  writer throughput and −44 % file size, but at least one popular
-  reader silently returns zero rows on such files; stays opt-in and
-  gated on the external-reader compat matrix.
+- ~~**Compact cell refs** (`c/@r` omitted, spec-legal)~~ — **shipped in
+  v3.3 as opt-in `compact()`** (~52–62 % smaller compressed sheets;
+  verified in Excel/LibreOffice/Numbers and read by PhpSpreadsheet 5.8 /
+  OpenSpout 4.28). Stays opt-in while it accrues field mileage.
 - **Retrofit index for foreign XLSX** — zran-style inflate-state
   snapshots make files *other* writers produced random-access after
   one pass. Pure PHP can't resume mid-stream (no `inflatePrime`);

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,15 @@ The following versions of `kolay/xlsx-stream` receive security updates:
 
 | Version | Supported          |
 |---------|--------------------|
-| 2.2.x   | :white_check_mark: |
-| 2.1.x   | :white_check_mark: |
-| 2.0.x   | :white_check_mark: |
+| 3.3.x   | :white_check_mark: |
+| 3.2.x   | :white_check_mark: |
+| < 3.2   | :x:                |
+| 2.x     | :x:                |
 | 1.x     | :x:                |
 
-Users on v1.x are encouraged to upgrade to v2.x. See [UPGRADE.md](UPGRADE.md)
-for migration steps.
+Users on older releases are encouraged to upgrade to the latest 3.x.
+See [UPGRADE.md](UPGRADE.md) for migration steps (all 3.x upgrades are
+backward-compatible).
 
 ## Reporting a Vulnerability
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -178,6 +178,17 @@ A sync point is a **resume marker inside the sheet's deflate stream**.
   Together these guarantee a reader can seek to `comp_offset`,
   initialize a fresh raw-inflate context with no history and no
   priming, and immediately tokenize whole rows.
+
+  > *Informative.* The window-reset property (2) is the single primitive
+  > several features share: because no compressed byte after a sync point
+  > references data before it, a sync point is simultaneously a **random-
+  > access seek target** (readers), a **block boundary** for per-block
+  > zone maps / running CRCs / group-aligned blocks (`STAT`/`SCRC` and a
+  > writer's group-boundary flushing), and a **crash-resume checkpoint**:
+  > the deflate dictionary is empty there, so a writer that snapshots its
+  > state at a sync point can resume and produce output **byte-identical**
+  > to an uninterrupted run. Anything claiming byte-identical resume MUST
+  > checkpoint only at sync points for this reason.
 - Sync points MUST be **strictly increasing** in `row`, in
   `comp_offset`, and in `uncomp_offset`.
 - `row` MUST NOT exceed `total_rows + 1`. The value `total_rows + 1` is

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -95,8 +95,9 @@ carries `'version' => 2`, so existing published copies stay inert and
 nothing changes until you opt in.
 
 **The safe way to opt in** is re-publishing the file, which ships the
-new defaults (they match the code: compression level 5, flush interval
-10,000, part size 8 MB, concurrency 4):
+current defaults (they match the code: compression level 5, flush
+interval 10,000, part size 8 MB, and — as of v3.3 — concurrency 1;
+see the v3.3.0 note above):
 
 ```bash
 php artisan vendor:publish --tag=xlsx-stream-config --force

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,62 @@
 # Upgrade Guide
 
+## Upgrading from v3.2.2 to v3.3.0
+
+No breaking API changes — every call site works unchanged, the base
+`Source` contract is unchanged, and classic writer output stays
+byte-identical (the new `compact()` and `syncAtGroupBoundaries()` modes
+are opt-in). There is **one behavioral change** to know about, plus a lot
+of new opt-in capability.
+
+### 1. S3 multipart uploads are now synchronous by default (memory fix)
+
+`S3MultipartSink`'s default `concurrency` changed from **4 to 1**. This
+fixes a real memory leak: the parallel (async) upload path let the AWS
+SDK's promise graph retain every part's body, so S3 write memory grew
+with the file (~130 MB at 3M rows, unbounded beyond) — the advertised
+"stream millions of rows to S3 with bounded memory" was silently
+O(file size). The synchronous default keeps memory flat at ~part size
+regardless of file size.
+
+- **You almost certainly want the new default.** On bandwidth-bound links
+  it is no slower than the old parallel default (both are network-bound)
+  and it is steadier.
+- **To restore parallel uploads** (only worth it on a high-latency link
+  where you have measured a throughput win), opt back in explicitly:
+
+  ```php
+  // Per sink:
+  new S3MultipartSink($s3, $bucket, $key, concurrency: 4);
+  // Or via config/env for forDisk() writers:
+  // XLSX_STREAM_S3_CONCURRENCY=4
+  ```
+
+  The parallel path now runs a per-part `gc_collect_cycles()` to bound its
+  footprint, but it is still a higher, sawtooth memory profile than the
+  synchronous default.
+
+### 2. New opt-in capabilities (nothing to change)
+
+All additive — adopt as you like:
+
+- **Query engine:** `rowsWhereAll()`, `estimatedRows()`/`explain()`,
+  `topRows()`, `sampleRows()`, column addressing by header name
+  (`columnStats('amount')`), `Readers\Bucket::month()` for `groupStats()`.
+- **Integrity:** `$reader->verify()` (block-granularity CRC check);
+  `new S3MultipartSink(..., verifyParts: true)` so S3 rejects a corrupted
+  part.
+- **Writer ergonomics:** `queryable([1,2,3])` (index + zone maps +
+  sketches in one call); `compact()` (r-less cells, ~52–62 % smaller
+  compressed sheets — opt-in while it accrues field mileage);
+  `syncAtGroupBoundaries(col)` (zero-scan `groupStats` on grouped exports).
+- **Observability:** `$reader->onFullScan(fn ($ctx) => …)` to detect when
+  a query isn't using the index.
+
+If you implement your own `Source`, note that bounded ranged reads are a
+new optional capability interface (`SupportsBoundedStream`) — you do NOT
+need to implement it; sources without it simply fetch to EOF and the
+reader caps the read.
+
 ## Upgrading from v3.2.0 / v3.2.1 to v3.2.2
 
 No breaking API changes — every call site works unchanged. One

--- a/config/xlsx-stream.php
+++ b/config/xlsx-stream.php
@@ -48,11 +48,14 @@ return [
         'part_size' => env('XLSX_STREAM_S3_PART_SIZE', 8 * 1024 * 1024),
 
         // Max part uploads in flight at once for forDisk() writers.
-        // Memory ceiling is roughly part_size x (concurrency + 1);
-        // 1 = strictly sequential uploads. Writers that need per-call
-        // control construct S3MultipartSink directly — its constructor
-        // takes both part size and concurrency.
-        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 4),
+        // DEFAULT 1 = strictly synchronous uploads: memory stays flat at
+        // ~part_size regardless of file size (true O(1)). Raise it to opt
+        // into PARALLEL part uploads, which can hide per-request latency on
+        // high-RTT links but hold more memory (the async path keeps each
+        // in-flight part's body until a periodic GC reclaims it — a higher,
+        // sawtooth profile). Prefer > 1 only where you have measured a
+        // throughput win; on bandwidth-bound links it is no faster.
+        'concurrency' => env('XLSX_STREAM_S3_CONCURRENCY', 1),
 
         // Why there are no retry keys here: transient upload errors are
         // retried by the AWS SDK's own retry middleware — configure it

--- a/src/Contracts/ProvidesCostHints.php
+++ b/src/Contracts/ProvidesCostHints.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Kolay\XlsxStream\Contracts;
+
+/**
+ * Optional capability: a Source that can describe its I/O cost so the
+ * reader can plan gap-bridging (G5). When a pruned scan leaves two
+ * surviving block runs separated by a short gap of non-matching blocks,
+ * it is often cheaper on a high-latency source to keep ONE ranged read
+ * alive straight through the gap than to pay a second round-trip. The
+ * reader bridges a gap when transferring its compressed bytes costs less
+ * than one round-trip: `gap_bytes / bandwidth_bps < rtt_us / 1e6`.
+ *
+ * Sources that do NOT implement this are treated as zero-latency (local
+ * disk): no gap is ever bridged and run merging stays byte-for-byte the
+ * contiguous-only behaviour. The numbers are deployment facts the Source
+ * knows (region round-trip, measured throughput) — never baked constants.
+ */
+interface ProvidesCostHints
+{
+    /**
+     * @return array{rtt_us: int, bandwidth_bps: int} round-trip latency in
+     *                                                 microseconds and
+     *                                                 throughput in bytes/sec
+     */
+    public function costHints(): array;
+}

--- a/src/Contracts/Source.php
+++ b/src/Contracts/Source.php
@@ -28,22 +28,20 @@ interface Source
     public function range(int $offset, int $length): string;
 
     /**
-     * Open a forward-only stream resource starting at the given offset.
-     * Caller is responsible for fclose(). The stream MUST support fread()
-     * and feof(); seeking is not required.
+     * Open a forward-only stream resource starting at the given offset,
+     * reading to the end of the object. Caller is responsible for
+     * fclose(). The stream MUST support fread() and feof(); seeking is not
+     * required.
      *
-     * When $length is given the stream is bounded to at most that many
-     * bytes from $offset (a ranged [offset, offset+length-1] fetch on
-     * remote sources; a read cap on local ones). $length === null keeps
-     * the historical behaviour of reading to the end of the object. The
-     * bound is an I/O optimization for pruned scans that stop at a
-     * ZLIB_FULL_FLUSH sync boundary — never a correctness contract on
-     * exact byte counts, so implementations may over-read to EOF if
-     * bounding is not cheap.
+     * A source that can serve a BOUNDED range cheaply (stopping after a
+     * given byte length, e.g. an HTTP Range GET) additionally implements
+     * SupportsBoundedStream — the reader uses that for pruned scans that
+     * end at a sync boundary. Sources that only implement this method keep
+     * working; they just fetch to EOF and let the reader cap the read.
      *
      * @return resource
      */
-    public function streamFrom(int $offset, ?int $length = null);
+    public function streamFrom(int $offset);
 
     /**
      * Release any underlying handles. Idempotent — safe to call multiple times.

--- a/src/Contracts/Source.php
+++ b/src/Contracts/Source.php
@@ -32,9 +32,18 @@ interface Source
      * Caller is responsible for fclose(). The stream MUST support fread()
      * and feof(); seeking is not required.
      *
+     * When $length is given the stream is bounded to at most that many
+     * bytes from $offset (a ranged [offset, offset+length-1] fetch on
+     * remote sources; a read cap on local ones). $length === null keeps
+     * the historical behaviour of reading to the end of the object. The
+     * bound is an I/O optimization for pruned scans that stop at a
+     * ZLIB_FULL_FLUSH sync boundary — never a correctness contract on
+     * exact byte counts, so implementations may over-read to EOF if
+     * bounding is not cheap.
+     *
      * @return resource
      */
-    public function streamFrom(int $offset);
+    public function streamFrom(int $offset, ?int $length = null);
 
     /**
      * Release any underlying handles. Idempotent — safe to call multiple times.

--- a/src/Contracts/SupportsBoundedStream.php
+++ b/src/Contracts/SupportsBoundedStream.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kolay\XlsxStream\Contracts;
+
+/**
+ * Optional capability: a Source that can open a stream bounded to a byte
+ * length — cheaply serving just [offset, offset+length-1] rather than
+ * reading to the end of the object.
+ *
+ * The reader uses this for pruned scans that stop at a ZLIB_FULL_FLUSH
+ * sync boundary: on a remote source (S3 range GET) it turns an open-ended
+ * [offset, EOF] fetch into an exact ranged read, so a query over an early
+ * block doesn't pull the whole file off the wire. It is purely an I/O
+ * optimization — a Source that does NOT implement this still works
+ * correctly (the reader falls back to streamFrom() and caps the read
+ * itself), so this stays out of the base Source contract to keep that
+ * contract stable for third-party implementations.
+ */
+interface SupportsBoundedStream
+{
+    /**
+     * Like Source::streamFrom($offset), but the returned stream serves at
+     * most $length bytes from $offset. The bound is an optimization, not a
+     * correctness contract on the exact byte count — an implementation may
+     * over-read (e.g. to EOF) when bounding is not cheap.
+     *
+     * @return resource
+     */
+    public function streamFromRange(int $offset, int $length);
+}

--- a/src/Exceptions/XlsxReadException.php
+++ b/src/Exceptions/XlsxReadException.php
@@ -45,4 +45,42 @@ class XlsxReadException extends XlsxStreamException
             'Tracked for a future v3.x release.'
         );
     }
+
+    /**
+     * A header name matched more than one column — silently picking one
+     * would be the silent-wrong-answer failure class, so the caller must
+     * disambiguate (rename the header or address the column by number).
+     *
+     * @param  list<int>  $positions  1-based column positions carrying the name
+     */
+    public static function ambiguousColumnName(string $name, array $positions): self
+    {
+        return new self(sprintf(
+            "Column name '%s' is ambiguous — it appears at positions %s. ".
+            'Address the column by number, or give the headers distinct names.',
+            $name,
+            implode(' and ', $positions)
+        ));
+    }
+
+    /**
+     * A header name resolved to nothing. The message carries the sheet's
+     * actual headers so a typo is a one-glance fix, not a debugging trip.
+     *
+     * @param  list<string>  $headers  the sheet's addressable header names
+     */
+    public static function unknownColumnName(string $name, array $headers): self
+    {
+        $shown = array_slice($headers, 0, 20);
+        $list = $shown === [] ? '(sheet has no addressable headers)' : "'".implode("', '", $shown)."'";
+        if (count($headers) > 20) {
+            $list .= sprintf(' … +%d more', count($headers) - 20);
+        }
+
+        return new self(sprintf(
+            "Unknown column name '%s'. Available headers: %s.",
+            $name,
+            $list
+        ));
+    }
 }

--- a/src/Readers/Bucket.php
+++ b/src/Readers/Bucket.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kolay\XlsxStream\Readers;
+
+/**
+ * Ready-made bucket callables for StreamingXlsxReader::groupStats() over
+ * a DATE column. groupStats groups by the raw stored value, which for a
+ * date cell is the Excel serial (days since 1899-12-30). These helpers
+ * turn a serial into a calendar-period key so "GROUP BY month" is one
+ * call instead of hand-rolling the serial → date arithmetic.
+ *
+ * The conversion mirrors the reader's serial convention exactly —
+ * unix = (serial − 25569) × 86400, where 25569 is the serial of the Unix
+ * epoch (1970-01-01) — and is evaluated in UTC so it never drifts with
+ * the host timezone. Every bucket here is MONOTONE (a later serial maps
+ * to an equal-or-greater key), which is what lets groupStats fold a
+ * group-pure block straight from the sidecar without reading its rows.
+ *
+ * Example:
+ *   $reader->groupStats('order_date', 'total', Bucket::month());
+ *   // => one row per YYYYMM with sum/count/min/max of total
+ */
+final class Bucket
+{
+    /** Serial of the Unix epoch (1970-01-01) in the 1899-12-30 system. */
+    private const UNIX_EPOCH_SERIAL = 25569;
+
+    /** Group by calendar year: serial => YYYY (e.g. 2026). */
+    public static function year(): \Closure
+    {
+        return static fn (float $serial): int => (int) gmdate('Y', self::toUnix($serial));
+    }
+
+    /** Group by calendar month: serial => YYYYMM (e.g. 202603). */
+    public static function month(): \Closure
+    {
+        return static fn (float $serial): int => (int) gmdate('Ym', self::toUnix($serial));
+    }
+
+    /** Group by calendar day: serial => YYYYMMDD (e.g. 20260315). */
+    public static function day(): \Closure
+    {
+        return static fn (float $serial): int => (int) gmdate('Ymd', self::toUnix($serial));
+    }
+
+    private static function toUnix(float $serial): int
+    {
+        return (int) (($serial - self::UNIX_EPOCH_SERIAL) * 86400);
+    }
+}

--- a/src/Readers/RandomAccessIndex.php
+++ b/src/Readers/RandomAccessIndex.php
@@ -698,22 +698,34 @@ class RandomAccessIndex
      * the target precedes every recorded sync point (caller should
      * stream from the start of the sheet) or when no points exist.
      *
-     * Sync points are stored in row order by the writer, so a forward
-     * linear walk suffices — for typical sheets there are at most a
-     * few hundred points which is well under any benchmark threshold.
+     * Sync points are stored in strictly increasing row order (the writer
+     * appends them per flush; the decoder validates monotonicity), so a
+     * binary search finds the last point at or before $targetRow in
+     * O(log N). This matters when there are many points — e.g.
+     * syncAtGroupBoundaries() on a high-cardinality group column emits one
+     * per group, so a naive per-call linear walk would be O(groups).
      *
      * @return array{row: int, comp_offset: int, uncomp_offset: int}|null
      */
     public function findSyncPoint(string $sheetEntry, int $targetRow): ?array
     {
         $points = $this->syncPointsByEntry[$sheetEntry] ?? [];
-        $best = null;
+        $n = count($points);
+        if ($n === 0 || $points[0]['row'] > $targetRow) {
+            return null;
+        }
 
-        foreach ($points as $sp) {
-            if ($sp['row'] <= $targetRow) {
-                $best = $sp;
+        // Last index whose row <= $targetRow.
+        $lo = 0;
+        $hi = $n - 1;
+        $best = null;
+        while ($lo <= $hi) {
+            $mid = intdiv($lo + $hi, 2);
+            if ($points[$mid]['row'] <= $targetRow) {
+                $best = $points[$mid];
+                $lo = $mid + 1;
             } else {
-                break;
+                $hi = $mid - 1;
             }
         }
 

--- a/src/Readers/StreamingSheetReader.php
+++ b/src/Readers/StreamingSheetReader.php
@@ -109,7 +109,7 @@ class StreamingSheetReader
      *
      * @return \Generator<int, array<int, mixed>>
      */
-    public function rowsFromOffset(?int $compOffset, int $startingRowNumber, ?int $fastForwardTo = null): \Generator
+    public function rowsFromOffset(?int $compOffset, int $startingRowNumber, ?int $fastForwardTo = null, ?int $compLength = null): \Generator
     {
         $rowNumber = $startingRowNumber;
         $buffer = '';
@@ -122,7 +122,7 @@ class StreamingSheetReader
         $skipRemaining = $fastForwardTo !== null ? max(0, $fastForwardTo - $startingRowNumber) : 0;
         $carry = '';
 
-        foreach ($this->inflatedChunks($compOffset) as $inflated) {
+        foreach ($this->inflatedChunks($compOffset, $compLength) as $inflated) {
             if ($skipRemaining > 0) {
                 $scan = $carry.$inflated;
                 $found = substr_count($scan, '</row>');
@@ -244,7 +244,7 @@ class StreamingSheetReader
      *
      * @return \Generator<int, string>
      */
-    private function inflatedChunks(?int $compOffset): \Generator
+    private function inflatedChunks(?int $compOffset, ?int $compLength = null): \Generator
     {
         $entry = $this->cd->entry($this->sheetEntry);
         if ($entry === null) {
@@ -261,9 +261,20 @@ class StreamingSheetReader
 
         $dataOffset = $this->cd->dataOffset($this->source, $this->sheetEntry);
         $startOffset = $dataOffset + ($compOffset ?? 0);
-        $compRemaining = $entry['compressed_size'] - ($compOffset ?? 0);
+        $entryRemaining = $entry['compressed_size'] - ($compOffset ?? 0);
 
-        $stream = $this->source->streamFrom($startOffset);
+        // A caller-supplied $compLength stops the read at a ZLIB_FULL_FLUSH
+        // sync boundary (the run's trailing block). Because a full flush
+        // already emits every byte before it, the bounded bytes are fed to
+        // inflate with NO_FLUSH and the loop stops WITHOUT a ZLIB_FINISH
+        // step — the exact inverse of seeking INTO a sync point, which the
+        // random-access index already does. $bounded === false is the
+        // historical path (read to entry end, then FINISH), preserved
+        // byte-for-byte when $compLength is null or reaches the entry end.
+        $compRemaining = $compLength !== null ? min($compLength, $entryRemaining) : $entryRemaining;
+        $bounded = $compRemaining < $entryRemaining;
+
+        $stream = $this->source->streamFrom($startOffset, $bounded ? $compRemaining : null);
 
         $inflate = null;
         if ($method === self::METHOD_DEFLATE) {
@@ -305,7 +316,12 @@ class StreamingSheetReader
                         $compRemaining -= $n;
 
                         if ($method === self::METHOD_DEFLATE) {
-                            $flag = $compRemaining === 0 ? ZLIB_FINISH : ZLIB_NO_FLUSH;
+                            // Bounded reads end at a full-flush boundary, so
+                            // the last chunk is still NO_FLUSH — never FINISH
+                            // (the flush already emitted its output; a FINISH
+                            // on a stream truncated before its BFINAL block
+                            // would error).
+                            $flag = ($compRemaining === 0 && ! $bounded) ? ZLIB_FINISH : ZLIB_NO_FLUSH;
                             if ($flag === ZLIB_FINISH) {
                                 $finishedFlush = true;
                             }
@@ -318,7 +334,7 @@ class StreamingSheetReader
                             $inflated = $compressed;
                         }
                     }
-                } elseif (! $finishedFlush) {
+                } elseif (! $finishedFlush && ! $bounded) {
                     $inflated = inflate_add($inflate, '', ZLIB_FINISH);
                     if ($inflated === false) {
                         throw XlsxReadException::inflateFailed('final inflate_add returned false');
@@ -330,7 +346,9 @@ class StreamingSheetReader
                     yield $inflated;
                 }
 
-                if ($compRemaining === 0 && $finishedFlush) {
+                // Bounded runs stop as soon as their bytes are consumed
+                // (no FINISH to wait for); unbounded runs wait for FINISH.
+                if ($compRemaining === 0 && ($finishedFlush || $bounded)) {
                     break;
                 }
             }

--- a/src/Readers/StreamingSheetReader.php
+++ b/src/Readers/StreamingSheetReader.php
@@ -236,6 +236,65 @@ class StreamingSheetReader
     }
 
     /**
+     * Integrity check: inflate the whole sheet once, running a CRC32 over
+     * the uncompressed bytes, and compare it against the sidecar's
+     * per-sync-point running-CRC pins (SCRC) and the whole-sheet CRC. This
+     * is the read-side counterpart of the CRC the writer pinned at each
+     * ZLIB_FULL_FLUSH boundary, so a corrupt block is localized to the two
+     * sync points that bracket it. O(1) memory (streaming inflate).
+     *
+     * A checkpoint is `[uncompOffset, expectedCrc]` — expectedCrc must equal
+     * the CRC32 of the first uncompOffset uncompressed bytes. $checkpoints
+     * must be ascending by offset. `inflate_ok=false` means the compressed
+     * data itself was too corrupt to inflate (a hard failure, reported not
+     * thrown so callers get a full report).
+     *
+     * @param  list<array{0: int, 1: int}>  $checkpoints
+     * @return array{sheet_crc_ok: bool, corrupt_blocks: list<int>, inflate_ok: bool}
+     */
+    public function verifyCrc(array $checkpoints, int $sheetCrc): array
+    {
+        $ctx = hash_init('crc32b');
+        $consumed = 0;
+        $ci = 0;
+        $n = count($checkpoints);
+        $corrupt = [];
+
+        try {
+            foreach ($this->inflatedChunks(null) as $chunk) {
+                $len = strlen($chunk);
+                $pos = 0;
+
+                // Close out every checkpoint whose boundary falls in this chunk.
+                while ($ci < $n && $checkpoints[$ci][0] <= $consumed + $len) {
+                    $upto = $checkpoints[$ci][0] - $consumed;
+                    if ($upto > $pos) {
+                        hash_update($ctx, substr($chunk, $pos, $upto - $pos));
+                        $pos = $upto;
+                    }
+                    if (hexdec(hash_final(hash_copy($ctx))) !== $checkpoints[$ci][1]) {
+                        $corrupt[] = $ci;
+                    }
+                    $ci++;
+                }
+
+                if ($pos < $len) {
+                    hash_update($ctx, substr($chunk, $pos));
+                }
+                $consumed += $len;
+            }
+        } catch (\Throwable) {
+            return ['sheet_crc_ok' => false, 'corrupt_blocks' => $corrupt, 'inflate_ok' => false];
+        }
+
+        return [
+            'sheet_crc_ok' => hexdec(hash_final($ctx)) === $sheetCrc,
+            'corrupt_blocks' => $corrupt,
+            'inflate_ok' => true,
+        ];
+    }
+
+    /**
      * Stream the sheet entry's inflated bytes as string chunks. Shared
      * engine behind rowsFromOffset() (row assembly) and countRows()
      * (boundary counting): entry validation, the ranged read loop, the

--- a/src/Readers/StreamingSheetReader.php
+++ b/src/Readers/StreamingSheetReader.php
@@ -3,6 +3,7 @@
 namespace Kolay\XlsxStream\Readers;
 
 use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Contracts\SupportsBoundedStream;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
 
 /**
@@ -333,7 +334,13 @@ class StreamingSheetReader
         $compRemaining = $compLength !== null ? min($compLength, $entryRemaining) : $entryRemaining;
         $bounded = $compRemaining < $entryRemaining;
 
-        $stream = $this->source->streamFrom($startOffset, $bounded ? $compRemaining : null);
+        // A source that can serve a bounded range (S3 range GET) fetches
+        // only the run's bytes off the wire; others fall back to a plain
+        // stream-to-EOF and the loop caps the read via $compRemaining. The
+        // NO_FLUSH / skip-FINISH handling below is identical either way.
+        $stream = ($bounded && $this->source instanceof SupportsBoundedStream)
+            ? $this->source->streamFromRange($startOffset, $compRemaining)
+            : $this->source->streamFrom($startOffset);
 
         $inflate = null;
         if ($method === self::METHOD_DEFLATE) {

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -1646,33 +1646,24 @@ class StreamingXlsxReader
     }
 
     /**
-     * CDF(x) = fraction of the column's values ≤ x, recovered by inverting
-     * the in-memory t-digest's quantile() with 40 bisection steps (the
-     * digest exposes quantile, not rank). Zero I/O. null when the column
-     * has no digest. Values below min converge to 0, above max to 1.
+     * CDF(x) = fraction of the column's values ≤ x, answered directly by
+     * the t-digest's rank() — a single O(centroids) pass through the same
+     * piecewise-linear model quantile() uses (rank and quantile are
+     * numerical inverses within the digest's resolution). Zero I/O. null
+     * when the column has no digest. Values below min → 0, above max → 1.
+     *
+     * Previously this inverted quantile() by bisecting it 40 times
+     * (40 × O(centroids)); rank() collapses that to one O(centroids) pass,
+     * ~80× fewer centroid walks for a 'between' estimate (two CDF lookups).
      */
     private function estimateCdf(int $column, float $x): ?float
     {
-        if ($this->quantile($column, 0.5) === null) {
-            return null;
+        $chain = $this->chain();
+        if ($chain !== null) {
+            return $this->chainDigest($chain, $column)?->rank($x);
         }
 
-        $lo = 0.0;
-        $hi = 1.0;
-        for ($i = 0; $i < 40; $i++) {
-            $mid = ($lo + $hi) / 2.0;
-            $v = $this->quantile($column, $mid);
-            if ($v === null) {
-                return null;
-            }
-            if ($v < $x) {
-                $lo = $mid;
-            } else {
-                $hi = $mid;
-            }
-        }
-
-        return ($lo + $hi) / 2.0;
+        return $this->loadRandomAccessIndex()?->columnDigest($this->currentEntry, $column)?->rank($x);
     }
 
     /**

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -1116,6 +1116,72 @@ class StreamingXlsxReader
     }
 
     /**
+     * A uniform random sample of $k rows, fetched via the index — so a
+     * sample of a multi-GB sheet costs ≈$k block reads, not a full scan.
+     * $k distinct row numbers are drawn uniformly (without replacement)
+     * from the data range with a seeded Mt19937 Randomizer, then exactly
+     * those rows are read; each data row has an equal $k/N chance
+     * (unbiasedness proven in poc/d3_sample.php via chi-square). The
+     * Randomizer is local — the global mt_rand() state is untouched.
+     *
+     * Pass $seed for a reproducible sample (same file + seed => same
+     * rows); omit it for a fresh secure-random draw. Returns an ascending
+     * map of 1-based row number => row (casts applied). Empty for
+     * $k <= 0; the whole table (in order) when $k >= the row count.
+     * Best for $k far below the total — at large $k a full rows() scan is
+     * cheaper than that many seeks.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    public function sampleRows(int $k, ?int $seed = null): array
+    {
+        if ($k <= 0) {
+            return [];
+        }
+
+        $total = $this->rowCount();
+        if ($total <= 1) {
+            return []; // header only, no data rows
+        }
+
+        $lo = 2;            // row 1 is the header
+        $hi = $total;
+        $n = $hi - $lo + 1;
+        $k = min($k, $n);
+
+        $rows = [];
+        if ($k === $n) {
+            foreach ($this->rowRange($lo, $hi) as $rn => $row) {
+                $rows[$rn] = $row;
+            }
+
+            return $rows;
+        }
+
+        $rng = new \Random\Randomizer(
+            $seed !== null ? new \Random\Engine\Mt19937($seed) : null
+        );
+
+        // Rejection sampling for k DISTINCT rows — getInt() is itself
+        // rejection-based, so no modulo bias; the set keys dedup draws.
+        // Efficient while k ≪ n, which is the intended use.
+        $picked = [];
+        while (count($picked) < $k) {
+            $picked[$rng->getInt($lo, $hi)] = true;
+        }
+        ksort($picked);
+
+        foreach (array_keys($picked) as $rn) {
+            $row = $this->rowAt($rn);
+            if ($row !== null) {
+                $rows[$rn] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
      * Sorted-column fast path: the k extremes are a contiguous block of
      * rows at one end of the sheet. Read just that row range (via the
      * seeking rowRange) and order it by value — no per-row comparison

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -88,6 +88,9 @@ class StreamingXlsxReader
     /** Memoized gap-bridge byte budget (rtt × bandwidth); see maxBridgeBytes(). */
     private ?int $bridgeBytesCache = null;
 
+    /** Observability hook fired when a query degrades to a full scan; see onFullScan(). */
+    private ?\Closure $onFullScan = null;
+
     /** @var list<array{name: string, sheetId: int, entry: string}> */
     private array $sheets;
 
@@ -872,6 +875,36 @@ class StreamingXlsxReader
     }
 
     /**
+     * Register a hook fired whenever a query CANNOT push down and falls
+     * back to a full row scan — an unindexed column on rowsWhere /
+     * rowsWhereAll, or a groupBy column that is not sorted / not tracked
+     * on groupStats. The callback receives a context array
+     * `{query, column, reason, entry}` so callers can log or alert when a
+     * query silently reads the whole sheet instead of the sidecar. Pass
+     * null to clear. On an auto-split chain it may fire once per member.
+     *
+     * @param  (callable(array{query: string, column: int|null, reason: string, entry: string}): void)|null  $callback
+     */
+    public function onFullScan(?callable $callback): self
+    {
+        $this->onFullScan = $callback === null ? null : \Closure::fromCallable($callback);
+
+        return $this;
+    }
+
+    private function fireFullScan(string $query, ?int $column, string $reason, string $entry): void
+    {
+        if ($this->onFullScan !== null) {
+            ($this->onFullScan)([
+                'query' => $query,
+                'column' => $column,
+                'reason' => $reason,
+                'entry' => $entry,
+            ]);
+        }
+    }
+
+    /**
      * Yield rows whose $column (1-based, see columnStats) satisfies a
      * numeric predicate, using the sidecar's per-block zone maps to skip
      * every block whose [min, max] provably contains no match — the
@@ -1350,6 +1383,7 @@ class StreamingXlsxReader
             // rows(): that wrapper re-keys sequentially from 0, while
             // this generator's contract (and the pruned path below) is
             // 1-based sheet row numbers.
+            $this->fireFullScan('rowsWhere', $column, 'column-not-indexed', $entry);
             foreach ($this->openSheetReader([$column - 1], $entry)->rowsFromOffset(null, 1) as $rn => $row) {
                 if ($this->cellMatches($row[$column - 1] ?? null, $op, $value, $value2)) {
                     yield $rn => $row;
@@ -1425,6 +1459,7 @@ class StreamingXlsxReader
 
         if ($candidate === null) {
             // No statful predicate — full scan, filter per row.
+            $this->fireFullScan('rowsWhereAll', null, 'no-indexed-predicate', $entry);
             foreach ($this->openSheetReader($columns, $entry)->rowsFromOffset(null, 1) as $rn => $row) {
                 if ($this->rowMatchesAll($row, $preds)) {
                     yield $rn => $row;
@@ -1927,6 +1962,10 @@ class StreamingXlsxReader
             // No pushdown basis — honest full scan with the same
             // grouping. Not via rows(): the scan must see 1-based row
             // numbers to exclude exactly the header.
+            $reason = ($groupCol === null || $aggCol === null || $index === null)
+                ? 'column-not-indexed'
+                : 'groupby-not-sorted';
+            $this->fireFullScan('groupStats', $groupBy, $reason, $entry);
             foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1], $entry)->rowsFromOffset(null, 1) as $rn => $row) {
                 if ($rn === 1) {
                     continue;

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -917,6 +917,156 @@ class StreamingXlsxReader
     }
 
     /**
+     * Yield rows satisfying EVERY predicate (a conjunction / AND), pruned
+     * by intersecting each predicate's surviving-block set. Because zone
+     * maps are sound, a row matching all predicates lives in a block that
+     * survives all of them, so the intersection can only shrink the
+     * candidate blocks — a query filtering on two differently-clustered
+     * columns reads far fewer blocks than either predicate alone.
+     *
+     * Each predicate is `[column, op, value, value2?]`: column is a
+     * 1-based index or a header name (resolved like rowsWhere), op is one
+     * of '=', '<', '<=', '>', '>=', 'between' ($value2 = inclusive upper
+     * bound). Predicates on columns without zone maps prune nothing but
+     * still filter per row. With no statful predicate at all it degrades
+     * to a full-scan filter. Yields 1-based row number => row (casts
+     * applied), chain-aware exactly like rowsWhere.
+     *
+     * @param  list<array{0: int|string, 1: string, 2: int|float, 3?: int|float|null}>  $predicates
+     * @return \Generator<int, array<int, mixed>>
+     */
+    public function rowsWhereAll(array $predicates): \Generator
+    {
+        if ($predicates === []) {
+            throw new \InvalidArgumentException('rowsWhereAll() requires at least one predicate');
+        }
+
+        $preds = [];
+        foreach ($predicates as $p) {
+            $col = $p[0];
+            if (\is_string($col)) {
+                $col = $this->resolveColumnName($col) + 1;
+            }
+            $preds[] = ['col' => $col, 'op' => $p[1], 'value' => $p[2], 'value2' => $p[3] ?? null];
+        }
+
+        $chain = $this->chain();
+        if ($chain !== null) {
+            foreach ($chain as $i => $m) {
+                foreach ($this->matchRowsAllIn($m['entry'], $preds) as $rn => $row) {
+                    if ($i > 0 && $rn === 1) {
+                        continue;
+                    }
+                    yield $m['globalStart'] + ($rn - $m['dataStartLocal']) => $this->applyCasts($row);
+                }
+            }
+
+            return;
+        }
+
+        foreach ($this->matchRowsAllIn($this->currentEntry, $preds) as $rn => $row) {
+            yield $rn => $this->applyCasts($row);
+        }
+    }
+
+    /**
+     * Estimate how many rows a single predicate selects — WITHOUT reading
+     * a row (answered entirely from the sidecar). Returns:
+     *   - upper: the summed value-count of the zone-map surviving blocks,
+     *     a HARD upper bound (never below the true match count);
+     *   - estimate: an approximate count from the t-digest (range ops:
+     *     count × ΔCDF, inverted from the in-memory digest by bisection)
+     *     or the HLL for '=' (count ÷ distinct), or null when the column
+     *     carries no sketch.
+     *
+     * Returns null when the column has no zone maps (no basis to bound).
+     * Chain-aware: bounds fold across continuation members (all-or-nothing).
+     *
+     * @return array{upper: int, estimate: int|null}|null
+     */
+    public function estimatedRows(int|string $column, string $op, int|float $value, int|float|null $value2 = null): ?array
+    {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
+
+        $upper = $this->survivingRowCount($column, $op, $value, $value2);
+        if ($upper === null) {
+            return null;
+        }
+
+        return ['upper' => $upper, 'estimate' => $this->estimateSelectivity($column, $op, $value, $value2)];
+    }
+
+    /**
+     * Describe the query plan rowsWhereAll() would run for a predicate
+     * set — WITHOUT executing it. Zero I/O; every number comes from the
+     * sidecar. Shape:
+     *   - strategy: 'zone-map-prune' (some predicate pruned blocks) or
+     *     'full-scan' (no statful predicate / no index);
+     *   - candidateBlocks: blocks surviving the intersection;
+     *   - runs: contiguous block runs to scan (each = one seek);
+     *   - estimatedRows: {upper: int|null, estimate: int|null} — upper is
+     *     the row-count bound of the candidate blocks; estimate assumes
+     *     predicate independence;
+     *   - estimatedBytes: compressed bytes the scan would fetch (the S3
+     *     range budget — exactly what bounded streamFrom will request).
+     *
+     * @param  list<array{0: int|string, 1: string, 2: int|float, 3?: int|float|null}>  $predicates
+     * @return array{strategy: string, candidateBlocks: int, runs: int, estimatedRows: array{upper: int|null, estimate: int|null}, estimatedBytes: int}
+     */
+    public function explain(array $predicates): array
+    {
+        if ($predicates === []) {
+            throw new \InvalidArgumentException('explain() requires at least one predicate');
+        }
+
+        $preds = [];
+        foreach ($predicates as $p) {
+            $col = $p[0];
+            if (\is_string($col)) {
+                $col = $this->resolveColumnName($col) + 1;
+            }
+            $preds[] = ['col' => $col, 'op' => $p[1], 'value' => $p[2], 'value2' => $p[3] ?? null];
+        }
+
+        $index = $this->loadRandomAccessIndex();
+        $chain = $this->chain();
+        $entries = $chain !== null ? array_map(fn ($m) => $m['entry'], $chain) : [$this->currentEntry];
+
+        $pruned = false;
+        $candidateBlocks = 0;
+        $runs = 0;
+        $bytes = 0;
+        $upper = 0;
+        $upperKnown = false;
+        foreach ($entries as $entry) {
+            $plan = $this->planAllIn($index, $entry, $preds);
+            if (! $plan['full']) {
+                $pruned = true;
+            }
+            $candidateBlocks += $plan['candidateBlocks'];
+            $runs += $plan['runs'];
+            $bytes += $plan['bytes'];
+            if ($plan['upper'] !== null) {
+                $upper += $plan['upper'];
+                $upperKnown = true;
+            }
+        }
+
+        return [
+            'strategy' => $pruned ? 'zone-map-prune' : 'full-scan',
+            'candidateBlocks' => $candidateBlocks,
+            'runs' => $runs,
+            'estimatedRows' => [
+                'upper' => $upperKnown ? $upper : null,
+                'estimate' => $this->estimateAnd($preds),
+            ],
+            'estimatedBytes' => $bytes,
+        ];
+    }
+
+    /**
      * Single-sheet predicate matcher behind rowsWhere(): zone-map
      * pruning + run-merged scans over one entry, yielding LOCAL 1-based
      * row number => raw matched row (casts belong to the caller). This
@@ -949,26 +1099,14 @@ class StreamingXlsxReader
 
         // Prune, then merge surviving adjacent blocks into runs so each
         // run costs one seek + one linear scan instead of per-block seeks.
-        $runs = [];
-        $run = null;
-        foreach ($stats['blocks'] as $i => $block) {
-            $survives = $block['count'] > 0 && $block['max'] >= $lo && $block['min'] <= $hi;
-            if ($survives) {
-                $run === null ? $run = [$i, $i] : $run[1] = $i;
-            } elseif ($run !== null) {
-                $runs[] = $run;
-                $run = null;
-            }
-        }
-        if ($run !== null) {
-            $runs[] = $run;
-        }
+        $runs = $this->mergeRuns($this->survivingBlocks($stats['blocks'], $lo, $hi));
 
         foreach ($runs as [$firstBlock, $lastBlock]) {
             $start = $ranges[$firstBlock];
             $stopRow = $ranges[$lastBlock]['last_row'];
+            $compLength = $this->runCompLength($ranges, $firstBlock, $lastBlock);
 
-            foreach ($this->openSheetReader([$column - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
+            foreach ($this->openSheetReader([$column - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row'], $compLength) as $rn => $row) {
                 if ($rn < $start['first_row']) {
                     continue;
                 }
@@ -980,6 +1118,372 @@ class StreamingXlsxReader
                 }
             }
         }
+    }
+
+    /**
+     * Single-sheet AND matcher behind rowsWhereAll(): intersect each
+     * statful predicate's surviving blocks, scan the (run-merged)
+     * intersection once, and yield rows satisfying every predicate.
+     * Yields LOCAL 1-based row => raw row (casts belong to the caller),
+     * mirroring matchRowsIn's contract.
+     *
+     * @param  list<array{col: int, op: string, value: int|float, value2: int|float|null}>  $preds
+     * @return \Generator<int, array<int, mixed>>
+     */
+    private function matchRowsAllIn(string $entry, array $preds): \Generator
+    {
+        $index = $this->loadRandomAccessIndex();
+
+        // Candidate blocks = intersection of the surviving-block sets of
+        // every predicate that HAS zone maps. A predicate on an untracked
+        // column can't prune (it is filtered per row below), so it simply
+        // doesn't constrain the candidate set. null = still unconstrained.
+        $candidate = null;
+        $readColumns = [];
+        foreach ($preds as $p) {
+            $readColumns[$p['col'] - 1] = true;
+            $stats = $index?->columnStats($entry, $p['col']);
+            if ($stats === null) {
+                // Validate the op even when it can't prune, so a bad op or
+                // a between without an upper bound fails fast like rowsWhere.
+                $this->pruneBounds($p['op'], $p['value'], $p['value2']);
+
+                continue;
+            }
+            [$lo, $hi] = $this->pruneBounds($p['op'], $p['value'], $p['value2']);
+            $survivors = $this->survivingBlocks($stats['blocks'], $lo, $hi);
+            $candidate = $candidate === null
+                ? $survivors
+                : array_values(array_intersect($candidate, $survivors));
+        }
+
+        $columns = array_keys($readColumns);
+
+        if ($candidate === null) {
+            // No statful predicate — full scan, filter per row.
+            foreach ($this->openSheetReader($columns, $entry)->rowsFromOffset(null, 1) as $rn => $row) {
+                if ($this->rowMatchesAll($row, $preds)) {
+                    yield $rn => $row;
+                }
+            }
+
+            return;
+        }
+
+        if ($candidate === []) {
+            return; // every block pruned
+        }
+
+        $ranges = $this->blockRanges($index, $entry);
+        foreach ($this->mergeRuns($candidate) as [$firstBlock, $lastBlock]) {
+            $start = $ranges[$firstBlock];
+            $stopRow = $ranges[$lastBlock]['last_row'];
+            $compLength = $this->runCompLength($ranges, $firstBlock, $lastBlock);
+
+            foreach ($this->openSheetReader($columns, $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row'], $compLength) as $rn => $row) {
+                if ($rn < $start['first_row']) {
+                    continue;
+                }
+                if ($rn > $stopRow) {
+                    break;
+                }
+                if ($this->rowMatchesAll($row, $preds)) {
+                    yield $rn => $row;
+                }
+            }
+        }
+    }
+
+    /**
+     * True when a raw row satisfies every predicate (numeric cells only,
+     * pre-cast values — same per-cell semantics as rowsWhere).
+     *
+     * @param  array<int, mixed>  $row
+     * @param  list<array{col: int, op: string, value: int|float, value2: int|float|null}>  $preds
+     */
+    private function rowMatchesAll(array $row, array $preds): bool
+    {
+        foreach ($preds as $p) {
+            if (! $this->cellMatches($row[$p['col'] - 1] ?? null, $p['op'], $p['value'], $p['value2'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Hard upper bound on the rows a single predicate can select: the
+     * summed value-count of its zone-map surviving blocks, folded across
+     * chain members. null when any member lacks stats for the column
+     * (all-or-nothing — a bound with a hole is not a bound).
+     */
+    private function survivingRowCount(int $column, string $op, int|float $value, int|float|null $value2): ?int
+    {
+        $index = $this->loadRandomAccessIndex();
+        if ($index === null) {
+            return null;
+        }
+
+        [$lo, $hi] = $this->pruneBounds($op, $value, $value2);
+        $chain = $this->chain();
+        $entries = $chain !== null ? array_map(fn ($m) => $m['entry'], $chain) : [$this->currentEntry];
+
+        $total = 0;
+        foreach ($entries as $entry) {
+            $stats = $index->columnStats($entry, $column);
+            if ($stats === null) {
+                return null;
+            }
+            foreach ($this->survivingBlocks($stats['blocks'], $lo, $hi) as $b) {
+                $total += $stats['blocks'][$b]['count'];
+            }
+        }
+
+        return $total;
+    }
+
+    /**
+     * Approximate row count for a single predicate from the sketches:
+     * HLL count/distinct for '=', t-digest ΔCDF × count for ranges. null
+     * when the column carries no digest/HLL.
+     */
+    private function estimateSelectivity(int $column, string $op, int|float $value, int|float|null $value2): ?int
+    {
+        if ($op === '=') {
+            $distinct = $this->countDistinct($column);
+            $stats = $this->columnStats($column);
+            if ($distinct === null || $distinct <= 0 || $stats === null) {
+                return null;
+            }
+
+            return (int) max(1, round($stats['count'] / $distinct));
+        }
+
+        $stats = $this->columnStats($column);
+        if ($stats === null) {
+            return null;
+        }
+        $count = $stats['count'];
+
+        if ($op === 'between') {
+            $lo = min((float) $value, (float) $value2);
+            $hi = max((float) $value, (float) $value2);
+            $cLo = $this->estimateCdf($column, $lo);
+            $cHi = $this->estimateCdf($column, $hi);
+            if ($cLo === null || $cHi === null) {
+                return null;
+            }
+
+            return (int) round($count * max(0.0, $cHi - $cLo));
+        }
+
+        $cdf = $this->estimateCdf($column, (float) $value);
+        if ($cdf === null) {
+            return null;
+        }
+        $frac = ($op === '>=' || $op === '>') ? 1.0 - $cdf : $cdf;
+
+        return (int) round($count * max(0.0, $frac));
+    }
+
+    /**
+     * CDF(x) = fraction of the column's values ≤ x, recovered by inverting
+     * the in-memory t-digest's quantile() with 40 bisection steps (the
+     * digest exposes quantile, not rank). Zero I/O. null when the column
+     * has no digest. Values below min converge to 0, above max to 1.
+     */
+    private function estimateCdf(int $column, float $x): ?float
+    {
+        if ($this->quantile($column, 0.5) === null) {
+            return null;
+        }
+
+        $lo = 0.0;
+        $hi = 1.0;
+        for ($i = 0; $i < 40; $i++) {
+            $mid = ($lo + $hi) / 2.0;
+            $v = $this->quantile($column, $mid);
+            if ($v === null) {
+                return null;
+            }
+            if ($v < $x) {
+                $lo = $mid;
+            } else {
+                $hi = $mid;
+            }
+        }
+
+        return ($lo + $hi) / 2.0;
+    }
+
+    /**
+     * Plan a predicate set over ONE entry without scanning: intersect the
+     * statful predicates' surviving blocks, then count candidate blocks,
+     * merged runs, the compressed byte budget of those runs and the
+     * row-count upper bound.
+     *
+     * @param  list<array{col: int, op: string, value: int|float, value2: int|float|null}>  $preds
+     * @return array{full: bool, candidateBlocks: int, runs: int, bytes: int, upper: int|null}
+     */
+    private function planAllIn(?RandomAccessIndex $index, string $entry, array $preds): array
+    {
+        $candidate = null;
+        if ($index !== null) {
+            foreach ($preds as $p) {
+                $stats = $index->columnStats($entry, $p['col']);
+                if ($stats === null) {
+                    continue;
+                }
+                [$lo, $hi] = $this->pruneBounds($p['op'], $p['value'], $p['value2']);
+                $survivors = $this->survivingBlocks($stats['blocks'], $lo, $hi);
+                $candidate = $candidate === null
+                    ? $survivors
+                    : array_values(array_intersect($candidate, $survivors));
+            }
+        }
+
+        $entrySize = $this->cd->entry($entry)['compressed_size'] ?? 0;
+
+        if ($candidate === null) {
+            // Full scan: read the whole entry, row count only if indexed.
+            return [
+                'full' => true,
+                'candidateBlocks' => 0,
+                'runs' => 1,
+                'bytes' => $entrySize,
+                'upper' => $index?->totalRows($entry),
+            ];
+        }
+
+        if ($candidate === []) {
+            return ['full' => false, 'candidateBlocks' => 0, 'runs' => 0, 'bytes' => 0, 'upper' => 0];
+        }
+
+        $ranges = $this->blockRanges($index, $entry);
+        $runs = $this->mergeRuns($candidate);
+        $bytes = 0;
+        $upper = 0;
+        foreach ($runs as [$firstBlock, $lastBlock]) {
+            $startComp = $ranges[$firstBlock]['comp_offset'] ?? 0;
+            $end = $ranges[$lastBlock + 1]['comp_offset'] ?? $entrySize;
+            $bytes += max(0, $end - $startComp);
+            for ($b = $firstBlock; $b <= $lastBlock; $b++) {
+                $upper += $ranges[$b]['last_row'] - $ranges[$b]['first_row'] + 1;
+            }
+        }
+
+        return [
+            'full' => false,
+            'candidateBlocks' => count($candidate),
+            'runs' => count($runs),
+            'bytes' => $bytes,
+            'upper' => $upper,
+        ];
+    }
+
+    /**
+     * Independence-assumption estimate for a conjunction: total rows ×
+     * Π(per-predicate selectivity). null when any predicate has no sketch
+     * to estimate from or the population is unknown.
+     *
+     * @param  list<array{col: int, op: string, value: int|float, value2: int|float|null}>  $preds
+     */
+    private function estimateAnd(array $preds): ?int
+    {
+        $population = $this->rowCount();
+        if ($population <= 0) {
+            return null;
+        }
+
+        $product = 1.0;
+        foreach ($preds as $p) {
+            $est = $this->estimatedRows($p['col'], $p['op'], $p['value'], $p['value2']);
+            if ($est === null || $est['estimate'] === null) {
+                return null;
+            }
+            $product *= min(1.0, $est['estimate'] / $population);
+        }
+
+        return (int) round($population * $product);
+    }
+
+    /**
+     * Zone-map survivor test for one predicate: the ascending list of
+     * block indices whose [min, max] range can hold a value in [lo, hi]
+     * (empty blocks and blocks entirely outside the band are pruned).
+     * Sound by construction — a matching row's block always survives, so
+     * pruning never drops a match. Reused by rowsWhere (single predicate),
+     * rowsWhereAll (intersection) and estimatedRows (bound).
+     *
+     * @param  list<array{min: float, max: float, sum: float, count: int, other: int}>  $statBlocks
+     * @return list<int>
+     */
+    private function survivingBlocks(array $statBlocks, float|int $lo, float|int $hi): array
+    {
+        $survivors = [];
+        foreach ($statBlocks as $i => $block) {
+            if ($block['count'] > 0 && $block['max'] >= $lo && $block['min'] <= $hi) {
+                $survivors[] = $i;
+            }
+        }
+
+        return $survivors;
+    }
+
+    /**
+     * Collapse an ascending list of surviving block indices into
+     * contiguous [firstBlock, lastBlock] runs, so each run costs one seek
+     * plus one linear scan instead of a seek per block. A gap in the
+     * indices (a pruned block between survivors) starts a new run.
+     *
+     * @param  list<int>  $blocks  ascending, no duplicates
+     * @return list<array{0: int, 1: int}>
+     */
+    private function mergeRuns(array $blocks): array
+    {
+        $runs = [];
+        $run = null;
+        $prev = null;
+        foreach ($blocks as $i) {
+            if ($run === null) {
+                $run = [$i, $i];
+            } elseif ($i === $prev + 1) {
+                $run[1] = $i;
+            } else {
+                $runs[] = $run;
+                $run = [$i, $i];
+            }
+            $prev = $i;
+        }
+        if ($run !== null) {
+            $runs[] = $run;
+        }
+
+        return $runs;
+    }
+
+    /**
+     * Compressed byte length of a surviving block run [firstBlock,
+     * lastBlock], from its starting sync point to the sync point that
+     * begins the block AFTER it (a ZLIB_FULL_FLUSH boundary). Passed to
+     * rowsFromOffset so a pruned scan fetches only the run's bytes
+     * instead of ranging to the entry end.
+     *
+     * Returns null when the run reaches the entry's final block (read to
+     * EOF, historical FINISH path) or when the trailing block sits before
+     * the first sync point (no recorded offset to bound at).
+     *
+     * @param  list<array{first_row: int, last_row: int, comp_offset: int|null, uncomp_offset: int|null, start_row_at_offset: int|null}>  $ranges
+     */
+    private function runCompLength(array $ranges, int $firstBlock, int $lastBlock): ?int
+    {
+        $next = $ranges[$lastBlock + 1]['comp_offset'] ?? null;
+        if ($next === null) {
+            return null;
+        }
+
+        return $next - ($ranges[$firstBlock]['comp_offset'] ?? 0);
     }
 
     /**

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -1211,10 +1211,11 @@ class StreamingXlsxReader
      * A uniform random sample of $k rows, fetched via the index — so a
      * sample of a multi-GB sheet costs ≈$k block reads, not a full scan.
      * $k distinct row numbers are drawn uniformly (without replacement)
-     * from the data range with a seeded Mt19937 Randomizer, then exactly
-     * those rows are read; each data row has an equal $k/N chance
-     * (unbiasedness proven in poc/d3_sample.php via chi-square). The
-     * Randomizer is local — the global mt_rand() state is untouched.
+     * from the data range with a seeded generator + rejection sampling,
+     * then exactly those rows are read; each data row has an equal $k/N
+     * chance (unbiasedness proven in poc/d3_sample.php via chi-square).
+     * The generator is self-contained — the global mt_rand() state is
+     * untouched, and it needs no PHP 8.2 ext-random.
      *
      * Pass $seed for a reproducible sample (same file + seed => same
      * rows); omit it for a fresh secure-random draw. Returns an ascending
@@ -1250,20 +1251,7 @@ class StreamingXlsxReader
             return $rows;
         }
 
-        $rng = new \Random\Randomizer(
-            $seed !== null ? new \Random\Engine\Mt19937($seed) : null
-        );
-
-        // Rejection sampling for k DISTINCT rows — getInt() is itself
-        // rejection-based, so no modulo bias; the set keys dedup draws.
-        // Efficient while k ≪ n, which is the intended use.
-        $picked = [];
-        while (count($picked) < $k) {
-            $picked[$rng->getInt($lo, $hi)] = true;
-        }
-        ksort($picked);
-
-        foreach (array_keys($picked) as $rn) {
+        foreach ($this->drawDistinctRowNumbers($lo, $hi, $k, $seed) as $rn) {
             $row = $this->rowAt($rn);
             if ($row !== null) {
                 $rows[$rn] = $row;
@@ -1271,6 +1259,53 @@ class StreamingXlsxReader
         }
 
         return $rows;
+    }
+
+    /**
+     * Draw $k DISTINCT row numbers uniformly from [$lo, $hi], ascending.
+     *
+     * ext-random's \Random\Randomizer is PHP 8.2+ and this package
+     * supports 8.1, so the draw uses a self-contained xorshift32 rather
+     * than the extension. Uniform without modulo bias (the top,
+     * range-incommensurate slice of the 32-bit output is rejected) and
+     * without replacement (the set keys dedup draws). Deterministic for a
+     * given $seed — same file + seed reproduces the sample — and seeded
+     * from the CSPRNG when $seed is null. The global mt_rand() state is
+     * never touched. Efficient while $k ≪ the range, the intended use.
+     *
+     * @return list<int>
+     */
+    private function drawDistinctRowNumbers(int $lo, int $hi, int $k, ?int $seed): array
+    {
+        $state = $seed !== null ? ($seed & 0xFFFFFFFF) : random_int(1, 0xFFFFFFFF);
+        // Scramble so adjacent small seeds (1, 2, …) start well separated.
+        $state = ($state ^ 0x9E3779B9) & 0xFFFFFFFF;
+        if ($state === 0) {
+            $state = 0x9E3779B9;   // xorshift32 must never sit at zero
+        }
+
+        $range = $hi - $lo + 1;
+        // Largest multiple of $range within the 32-bit output space; draws
+        // at or above it are rejected so every residue is equally likely.
+        $limit = intdiv(0x100000000, $range) * $range;
+
+        $picked = [];
+        while (count($picked) < $k) {
+            // xorshift32 — every op stays within a 64-bit int (masked to 32).
+            $state ^= ($state << 13) & 0xFFFFFFFF;
+            $state ^= $state >> 17;
+            $state ^= ($state << 5) & 0xFFFFFFFF;
+            $state &= 0xFFFFFFFF;
+
+            if ($state >= $limit) {
+                continue;   // reject the biased tail
+            }
+            $picked[$lo + ($state % $range)] = true;
+        }
+
+        ksort($picked);
+
+        return array_keys($picked);
     }
 
     /**

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -451,6 +451,65 @@ class StreamingXlsxReader
     }
 
     /**
+     * Verify every sheet's data against the checksums the writer recorded,
+     * a single inflate pass per sheet at O(1) memory. On born-indexed files
+     * this checks the per-block running CRC (SCRC) pinned at each sync point
+     * AND the whole-sheet CRC, so corruption is localized: `corrupt_blocks`
+     * lists the 0-based sync-point index of each block whose bytes no longer
+     * match — the "which block went bad" report for audit/payroll/HR data.
+     * Without a sidecar it falls back to the whole-entry ZIP CRC only (no
+     * block granularity). `inflate_ok=false` marks a sheet whose compressed
+     * bytes were too damaged to inflate at all.
+     *
+     * @return array{ok: bool, sheets: list<array{sheet: int, entry: string, ok: bool, blocks_checked: int, corrupt_blocks: list<int>, sheet_crc_ok: bool, inflate_ok: bool}>}
+     */
+    public function verify(): array
+    {
+        $index = $this->loadRandomAccessIndex();
+        $sheets = [];
+        $allOk = true;
+
+        foreach ($this->sheets as $i => $sheet) {
+            $entry = $sheet['entry'];
+            $indexed = $index !== null && $index->sheetCrc32($entry) !== null;
+
+            if ($indexed) {
+                $sheetCrc = $index->sheetCrc32($entry);
+                $syncPoints = $index->syncPoints($entry);
+                $syncCrcs = $index->syncPointCrcs($entry);
+                $checkpoints = [];
+                foreach ($syncPoints as $k => $sp) {
+                    if (isset($syncCrcs[$k], $sp['uncomp_offset'])) {
+                        $checkpoints[] = [$sp['uncomp_offset'], $syncCrcs[$k]];
+                    }
+                }
+            } else {
+                // No SCRC pins — verify the whole entry against the ZIP's own CRC.
+                $sheetCrc = $this->cd->entry($entry)['crc32'] ?? -1;
+                $checkpoints = [];
+            }
+
+            $res = (new StreamingSheetReader($this->source, $this->cd, $entry))
+                ->verifyCrc($checkpoints, $sheetCrc);
+
+            $sheetOk = $res['inflate_ok'] && $res['sheet_crc_ok'] && $res['corrupt_blocks'] === [];
+            $allOk = $allOk && $sheetOk;
+
+            $sheets[] = [
+                'sheet' => $i,
+                'entry' => $entry,
+                'ok' => $sheetOk,
+                'blocks_checked' => count($checkpoints),
+                'corrupt_blocks' => $res['corrupt_blocks'],
+                'sheet_crc_ok' => $res['sheet_crc_ok'],
+                'inflate_ok' => $res['inflate_ok'],
+            ];
+        }
+
+        return ['ok' => $allOk, 'sheets' => $sheets];
+    }
+
+    /**
      * Return a single row by 1-based row number — row 1 is the header,
      * row 2 is the first data row. Returns null when $rowNumber is past
      * the end of the sheet.

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -1932,7 +1932,8 @@ class StreamingXlsxReader
             [$first, $last] = $step['scan'];
             $start = $ranges[$first];
             $stopRow = $ranges[$last]['last_row'];
-            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row']) as $rn => $row) {
+            $compLength = $this->runCompLength($ranges, $first, $last);
+            foreach ($this->openSheetReader([$groupBy - 1, $aggregate - 1], $entry)->rowsFromOffset($start['comp_offset'], $start['start_row_at_offset'] ?? 1, $start['first_row'], $compLength) as $rn => $row) {
                 if ($rn > $stopRow) {
                     break;
                 }

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -1201,7 +1201,7 @@ class StreamingXlsxReader
         $sorted = $stats['sorted'] ?? null;
 
         if ($sorted === 'asc' || $sorted === 'desc') {
-            return $this->topRowsSorted($k, $desc, $sorted, $total);
+            return $this->topRowsSorted($column, $k, $desc, $sorted, $total);
         }
 
         return $this->topRowsScan($column, $k, $desc);
@@ -1309,38 +1309,82 @@ class StreamingXlsxReader
     }
 
     /**
-     * Sorted-column fast path: the k extremes are a contiguous block of
-     * rows at one end of the sheet. Read just that row range (via the
-     * seeking rowRange) and order it by value — no per-row comparison
-     * needed, the sorted flag guarantees value order equals row order.
+     * Sorted-column path: the k extremes are the k NUMERIC cells nearest
+     * one end of the sheet. On an asc column the largest sit at the tail
+     * and the smallest at the head ($desc flips which end); a desc column
+     * mirrors it. We read outward from the wanted end and keep numeric
+     * rows until k are gathered.
+     *
+     * The sorted flag orders only numeric cells — null/text may sit
+     * anywhere, including the ends — so the old "read exactly the k rows
+     * at the end" shortcut could return non-numeric cells instead of the
+     * true extremes when the end held any. A fully-numeric end still fills
+     * on the first k-row read (the O(k) fast path); non-numeric cells at
+     * that end just widen the window. This is exact: reading inward from
+     * the extreme end, no numeric row past those already gathered can
+     * outrank them, so interior nulls never force extra work. If the
+     * non-numeric run at the end is long enough that we would read a large
+     * slice of the sheet, a single ordered scan is cheaper — bail to it.
      *
      * @return array<int, array<int, mixed>>
      */
-    private function topRowsSorted(int $k, bool $desc, string $sorted, int $total): array
+    private function topRowsSorted(int $column, int $k, bool $desc, string $sorted, int $total): array
     {
-        // Which end holds the wanted extreme? On an asc column high values
-        // sit at the tail; on desc, at the head. We want the high end when
-        // $desc (largest) is requested.
-        $wantHigh = $desc;
-        $highAtTail = $sorted === 'asc';
-        $readTail = $wantHigh === $highAtTail;
+        $idx = $column - 1;
+        $readTail = $desc === ($sorted === 'asc');
+        $bailAfter = max($k * 4, 4096);
 
-        [$from, $to] = $readTail ? [$total - $k + 1, $total] : [2, $k + 1];
+        $collected = [];   // rn => cast row, gathered most-extreme first
+        $scanned = 0;
+        $chunk = max($k, 1);
+        $cursor = $readTail ? $total : 2;   // moving edge at the wanted end
 
-        $rows = [];
-        foreach ($this->rowRange($from, $to) as $rn => $row) {
-            $rows[$rn] = $row;
+        while (\count($collected) < $k) {
+            if ($readTail) {
+                $hi = $cursor;
+                if ($hi < 2) {
+                    break;
+                }
+                $lo = max(2, $hi - $chunk + 1);
+            } else {
+                $lo = $cursor;
+                if ($lo > $total) {
+                    break;
+                }
+                $hi = min($total, $lo + $chunk - 1);
+            }
+
+            $numeric = [];
+            foreach ($this->rowRange($lo, $hi) as $rn => $row) {
+                if (is_numeric($row[$idx] ?? null)) {
+                    $numeric[$rn] = $row;   // rowRange already applies casts
+                }
+            }
+            $scanned += $hi - $lo + 1;
+
+            // Most-extreme first: highest row for a tail read (largest
+            // value on an asc column), lowest row for a head read.
+            $readTail ? krsort($numeric) : ksort($numeric);
+            foreach ($numeric as $rn => $row) {
+                $collected[$rn] = $row;
+                if (\count($collected) >= $k) {
+                    break;
+                }
+            }
+
+            // Whole sheet consumed?
+            if (($readTail && $lo <= 2) || (! $readTail && $hi >= $total)) {
+                break;
+            }
+            if ($scanned >= $bailAfter && \count($collected) < $k) {
+                return $this->topRowsScan($column, $k, $desc);
+            }
+
+            $cursor = $readTail ? $lo - 1 : $hi + 1;
+            $chunk = min($chunk * 4, 65536);
         }
 
-        // $rows is keyed by ascending row number. Value ascends with row
-        // number iff the column is asc-sorted. Reorder so position 0 is
-        // the requested top (high first when $desc).
-        $ascendingByValue = $sorted === 'asc';
-        if ($ascendingByValue === $desc) {
-            $rows = array_reverse($rows, true);
-        }
-
-        return $rows;
+        return $collected;
     }
 
     /**

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -144,6 +144,18 @@ class StreamingXlsxReader
      */
     private array $headerByEntry = [];
 
+    /**
+     * Header-name resolution cache per sheet entry: 'map' (name =>
+     * 0-based index, unique names only), 'dupes' (name => every 0-based
+     * position, for the ambiguity error), 'headers' (addressable names
+     * in sheet order, for the unknown-name error). Built lazily by
+     * resolveColumnName(); entry-keyed, so sheet switches need no
+     * invalidation.
+     *
+     * @var array<string, array{map: array<string, int>, dupes: array<string, list<int>>, headers: list<string>}>
+     */
+    private array $columnNamesByEntry = [];
+
     /** @var array<string, TDigest|null> merged chain digests, keyed chain-head|column */
     private array $chainDigestCache = [];
 
@@ -581,7 +593,12 @@ class StreamingXlsxReader
      *
      * $column is 1-based, matching the writer's withColumnStats() —
      * this API pairs with that opt-in (unlike castColumn(), whose
-     * 0-based indexing addresses the yielded row arrays).
+     * 0-based indexing addresses the yielded row arrays). A header
+     * NAME works everywhere a column number does — 'Amount' instead
+     * of 4 — and makes that base split invisible; naming semantics
+     * live on resolveColumnName(). Every query API below (quantile,
+     * median, countDistinct, rowsWhere, findRow, groupStats) accepts
+     * the same int|string form.
      *
      * Returns null when the file carries no stats for the column (not
      * born-indexed, stale sidecar, or column not tracked) — callers
@@ -593,8 +610,11 @@ class StreamingXlsxReader
      *
      * @return array{min: float|null, max: float|null, sum: float, avg: float|null, count: int, other: int, sorted: string|null}|null
      */
-    public function columnStats(int $column): ?array
+    public function columnStats(int|string $column): ?array
     {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
         $index = $this->loadRandomAccessIndex();
 
         // Chain: fold every member's blocks — the sidecar carries each
@@ -718,8 +738,11 @@ class StreamingXlsxReader
      * decide whether an exact scan is worth it. Also null for a sketch
      * that saw no numeric values (e.g. a text column).
      */
-    public function quantile(int $column, float $q): ?float
+    public function quantile(int|string $column, float $q): ?float
     {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
         if ($q < 0.0 || $q > 1.0) {
             throw new \InvalidArgumentException("quantile must be within [0, 1]; got {$q}");
         }
@@ -772,7 +795,7 @@ class StreamingXlsxReader
     /**
      * Approximate median — sugar for quantile($column, 0.5).
      */
-    public function median(int $column): ?float
+    public function median(int|string $column): ?float
     {
         return $this->quantile($column, 0.5);
     }
@@ -792,8 +815,11 @@ class StreamingXlsxReader
      * Returns null when the file carries no sketch for the column;
      * 0 for a tracked column whose data rows were all empty.
      */
-    public function countDistinct(int $column): ?int
+    public function countDistinct(int|string $column): ?int
     {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
         $chain = $this->chain();
         if ($chain !== null) {
             return $this->chainHll($chain, $column)?->count();
@@ -859,8 +885,12 @@ class StreamingXlsxReader
      *
      * @return \Generator<int, array<int, mixed>>
      */
-    public function rowsWhere(int $column, string $op, int|float $value, int|float|null $value2 = null): \Generator
+    public function rowsWhere(int|string $column, string $op, int|float $value, int|float|null $value2 = null): \Generator
     {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
+
         // Chain: run the per-sheet matcher over every member in order,
         // remapping local row numbers to the chain's global numbering.
         // Continuation members' repeated header row (local 1) is
@@ -967,7 +997,7 @@ class StreamingXlsxReader
      *
      * @return array{row: int, values: array<int, mixed>}|null
      */
-    public function findRow(int $column, int|float $value): ?array
+    public function findRow(int|string $column, int|float $value): ?array
     {
         foreach ($this->rowsWhere($column, '=', $value) as $rn => $row) {
             return ['row' => $rn, 'values' => $row];
@@ -1034,8 +1064,14 @@ class StreamingXlsxReader
      * @param  callable(float): (int|float)  $bucket
      * @return list<array{group: int|float, sum: float, count: int, min: float|null, max: float|null}>
      */
-    public function groupStats(int $groupBy, int $aggregate, ?callable $bucket = null): array
+    public function groupStats(int|string $groupBy, int|string $aggregate, ?callable $bucket = null): array
     {
+        if (\is_string($groupBy)) {
+            $groupBy = $this->resolveColumnName($groupBy) + 1;
+        }
+        if (\is_string($aggregate)) {
+            $aggregate = $this->resolveColumnName($aggregate) + 1;
+        }
         if ($groupBy < 1 || $aggregate < 1) {
             throw new \InvalidArgumentException(
                 "groupStats() columns are 1-based; got groupBy={$groupBy}, aggregate={$aggregate}"
@@ -1586,7 +1622,9 @@ class StreamingXlsxReader
     }
 
     /**
-     * Register a cell-value cast for a 0-indexed column. Built-in cast
+     * Register a cell-value cast for a column — 0-indexed number, or a
+     * header NAME (see resolveColumnName; addressing by name makes the
+     * 0-based-here vs 1-based-in-queries split invisible). Built-in cast
      * names: date, datetime, int, float, bool. Pass a callable for
      * custom transformations.
      *
@@ -1598,8 +1636,12 @@ class StreamingXlsxReader
      * column is exempted from detection, so the cast always receives
      * the raw tokenized value, never a DateTimeImmutable.
      */
-    public function castColumn(int $col, string|callable $cast): self
+    public function castColumn(int|string $col, string|callable $cast): self
     {
+        if (is_string($col)) {
+            $col = $this->resolveColumnName($col); // 0-based, castColumn's native base
+        }
+
         // String is always interpreted as a built-in cast name (date,
         // datetime, int, float, bool). is_callable() must NOT win the
         // dispatch here — "date" is a real PHP function, so a naive
@@ -1612,9 +1654,14 @@ class StreamingXlsxReader
     }
 
     /**
-     * Bulk variant of castColumn().
+     * Bulk variant of castColumn(). Keys may be 0-based numbers or
+     * header names. PHP coerces numeric-string ARRAY KEYS ('5') to
+     * ints before we ever see them, so a header literally named "5"
+     * cannot be addressed through this bulk form — use
+     * castColumn('5', ...) for that (the parameter form keeps the
+     * string intact).
      *
-     * @param  array<int, string|callable>  $casts
+     * @param  array<int|string, string|callable>  $casts
      */
     public function castColumns(array $casts): self
     {
@@ -1991,6 +2038,66 @@ class StreamingXlsxReader
         }
 
         return null;
+    }
+
+    /**
+     * Resolve a header NAME to its 0-based column index — the single
+     * naming authority behind every int|string API.
+     *
+     * Semantics (deliberate, uniform):
+     *   - A string is ALWAYS a name. '2024' looks up a header called
+     *     "2024"; it is never coerced to column 2024 — silent numeric
+     *     reinterpretation is exactly the ambiguity this API removes.
+     *   - Names match the RAW tokenized header row (before casts /
+     *     date detection), compared on the cells' string form. On a
+     *     continuation chain every member carries an identical header,
+     *     so the active entry's header speaks for the whole chain.
+     *   - Empty header cells are not addressable (skipped, not an error).
+     *   - A duplicated name throws ambiguousColumnName — silently
+     *     picking one column is the silent-wrong-answer failure class.
+     *   - An unknown name throws unknownColumnName listing the sheet's
+     *     headers, so a typo is a one-glance fix.
+     *
+     * The map builds once per sheet entry and is memoized; lookups are
+     * O(1) after that.
+     */
+    private function resolveColumnName(string $name): int
+    {
+        $entry = $this->currentEntry;
+        if (! isset($this->columnNamesByEntry[$entry])) {
+            $map = [];
+            $dupes = [];
+            $headers = [];
+            foreach ($this->rawHeaderOf($entry) as $idx => $cell) {
+                $label = (string) $cell;
+                if ($label === '') {
+                    continue;
+                }
+                $headers[] = $label;
+                if (isset($dupes[$label])) {
+                    $dupes[$label][] = $idx;
+                } elseif (isset($map[$label])) {
+                    $dupes[$label] = [$map[$label], $idx];
+                } else {
+                    $map[$label] = $idx;
+                }
+            }
+            $this->columnNamesByEntry[$entry] = ['map' => $map, 'dupes' => $dupes, 'headers' => $headers];
+        }
+
+        $names = $this->columnNamesByEntry[$entry];
+
+        if (isset($names['dupes'][$name])) {
+            throw XlsxReadException::ambiguousColumnName(
+                $name,
+                array_map(static fn (int $i): int => $i + 1, $names['dupes'][$name])
+            );
+        }
+        if (! array_key_exists($name, $names['map'])) {
+            throw XlsxReadException::unknownColumnName($name, $names['headers']);
+        }
+
+        return $names['map'][$name];
     }
 
     /**

--- a/src/Readers/StreamingXlsxReader.php
+++ b/src/Readers/StreamingXlsxReader.php
@@ -3,6 +3,7 @@
 namespace Kolay\XlsxStream\Readers;
 
 use Aws\S3\S3Client;
+use Kolay\XlsxStream\Contracts\ProvidesCostHints;
 use Kolay\XlsxStream\Contracts\Source;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
 use Kolay\XlsxStream\Sketches\HyperLogLog;
@@ -83,6 +84,9 @@ class StreamingXlsxReader
 
     private Source $source;
     private ZipDirectory $cd;
+
+    /** Memoized gap-bridge byte budget (rtt × bandwidth); see maxBridgeBytes(). */
+    private ?int $bridgeBytesCache = null;
 
     /** @var list<array{name: string, sheetId: int, entry: string}> */
     private array $sheets;
@@ -1067,6 +1071,200 @@ class StreamingXlsxReader
     }
 
     /**
+     * "ORDER BY $column [DESC] LIMIT $k" answered from the sidecar:
+     * return the $k rows with the smallest ($desc = false) or largest
+     * ($desc = true) values in $column, ranked by that value.
+     *
+     * On a column the writer flagged sorted, the extremes are the rows at
+     * one end of the sheet, so only the blocks at that end are read (one
+     * seek, early exit) — an indexed top-N. On an unsorted column it is a
+     * single full scan holding an O($k) heap (no pruning is possible, but
+     * memory stays bounded). Ranking uses the raw stored numeric value —
+     * the same value columnStats/rowsWhere see — while the returned rows
+     * carry any registered casts. Non-numeric cells never rank.
+     *
+     * Returns an ordered map of 1-based row number => row (rank order:
+     * position 0 is the top). Empty for $k <= 0 or a header-only sheet;
+     * $k is clamped to the available data rows.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    public function topRows(int|string $column, int $k, bool $desc = false): array
+    {
+        if (\is_string($column)) {
+            $column = $this->resolveColumnName($column) + 1;
+        }
+        if ($k <= 0) {
+            return [];
+        }
+
+        $total = $this->rowCount();
+        $dataRows = $total - 1; // row 1 is the header
+        if ($dataRows <= 0) {
+            return [];
+        }
+        $k = min($k, $dataRows);
+
+        $stats = $this->columnStats($column);
+        $sorted = $stats['sorted'] ?? null;
+
+        if ($sorted === 'asc' || $sorted === 'desc') {
+            return $this->topRowsSorted($k, $desc, $sorted, $total);
+        }
+
+        return $this->topRowsScan($column, $k, $desc);
+    }
+
+    /**
+     * Sorted-column fast path: the k extremes are a contiguous block of
+     * rows at one end of the sheet. Read just that row range (via the
+     * seeking rowRange) and order it by value — no per-row comparison
+     * needed, the sorted flag guarantees value order equals row order.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    private function topRowsSorted(int $k, bool $desc, string $sorted, int $total): array
+    {
+        // Which end holds the wanted extreme? On an asc column high values
+        // sit at the tail; on desc, at the head. We want the high end when
+        // $desc (largest) is requested.
+        $wantHigh = $desc;
+        $highAtTail = $sorted === 'asc';
+        $readTail = $wantHigh === $highAtTail;
+
+        [$from, $to] = $readTail ? [$total - $k + 1, $total] : [2, $k + 1];
+
+        $rows = [];
+        foreach ($this->rowRange($from, $to) as $rn => $row) {
+            $rows[$rn] = $row;
+        }
+
+        // $rows is keyed by ascending row number. Value ascends with row
+        // number iff the column is asc-sorted. Reorder so position 0 is
+        // the requested top (high first when $desc).
+        $ascendingByValue = $sorted === 'asc';
+        if ($ascendingByValue === $desc) {
+            $rows = array_reverse($rows, true);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Unsorted-column path: a single full scan keeping the running top-k
+     * by raw value in an O(k) heap-like array. Casts are applied only to
+     * the surviving rows.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    private function topRowsScan(int $column, int $k, bool $desc): array
+    {
+        $idx = $column - 1;
+        $top = [];          // rn => ['v' => float, 'row' => raw row]
+        $threshold = null;  // worst value currently kept (evict candidate)
+
+        foreach ($this->scanAllRaw() as $rn => $row) {
+            $cell = $row[$idx] ?? null;
+            if (! is_numeric($cell)) {
+                continue;
+            }
+            $v = (float) $cell;
+
+            if (count($top) < $k) {
+                $top[$rn] = ['v' => $v, 'row' => $row];
+                if (count($top) === $k) {
+                    $threshold = $this->worstValue($top, $desc);
+                }
+
+                continue;
+            }
+
+            // Only touch the heap when the new value beats the weakest one.
+            if ($desc ? $v > $threshold : $v < $threshold) {
+                unset($top[$this->worstRow($top, $desc)]);
+                $top[$rn] = ['v' => $v, 'row' => $row];
+                $threshold = $this->worstValue($top, $desc);
+            }
+        }
+
+        uasort($top, fn ($a, $b) => $desc ? ($b['v'] <=> $a['v']) : ($a['v'] <=> $b['v']));
+
+        $out = [];
+        foreach ($top as $rn => $e) {
+            $out[$rn] = $this->applyCasts($e['row']);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Weakest value in the current top-k (the min when ranking largest,
+     * the max when ranking smallest) — the eviction threshold.
+     *
+     * @param  array<int, array{v: float, row: array<int, mixed>}>  $top
+     */
+    private function worstValue(array $top, bool $desc): float
+    {
+        $worst = null;
+        foreach ($top as $e) {
+            if ($worst === null || ($desc ? $e['v'] < $worst : $e['v'] > $worst)) {
+                $worst = $e['v'];
+            }
+        }
+
+        return $worst ?? 0.0;
+    }
+
+    /**
+     * Row number of the weakest entry in the current top-k.
+     *
+     * @param  array<int, array{v: float, row: array<int, mixed>}>  $top
+     */
+    private function worstRow(array $top, bool $desc): int
+    {
+        $worstRn = array_key_first($top);
+        $worstV = null;
+        foreach ($top as $rn => $e) {
+            if ($worstV === null || ($desc ? $e['v'] < $worstV : $e['v'] > $worstV)) {
+                $worstV = $e['v'];
+                $worstRn = $rn;
+            }
+        }
+
+        return $worstRn;
+    }
+
+    /**
+     * Chain-aware full scan yielding global 1-based row number => raw row
+     * (no casts), header rows skipped. Backs the unsorted topRows path.
+     *
+     * @return \Generator<int, array<int, mixed>>
+     */
+    private function scanAllRaw(): \Generator
+    {
+        $chain = $this->chain();
+        if ($chain !== null) {
+            foreach ($chain as $m) {
+                foreach ($this->openSheetReader([], $m['entry'])->rowsFromOffset(null, 1) as $rn => $row) {
+                    if ($rn === 1) {
+                        continue; // header (real on member 0, repeated on continuations)
+                    }
+                    yield $m['globalStart'] + ($rn - $m['dataStartLocal']) => $row;
+                }
+            }
+
+            return;
+        }
+
+        foreach ($this->openSheetReader()->rowsFromOffset(null, 1) as $rn => $row) {
+            if ($rn === 1) {
+                continue;
+            }
+            yield $rn => $row;
+        }
+    }
+
+    /**
      * Single-sheet predicate matcher behind rowsWhere(): zone-map
      * pruning + run-merged scans over one entry, yielding LOCAL 1-based
      * row number => raw matched row (casts belong to the caller). This
@@ -1099,7 +1297,7 @@ class StreamingXlsxReader
 
         // Prune, then merge surviving adjacent blocks into runs so each
         // run costs one seek + one linear scan instead of per-block seeks.
-        $runs = $this->mergeRuns($this->survivingBlocks($stats['blocks'], $lo, $hi));
+        $runs = $this->planRuns($this->survivingBlocks($stats['blocks'], $lo, $hi), $ranges, $this->maxBridgeBytes());
 
         foreach ($runs as [$firstBlock, $lastBlock]) {
             $start = $ranges[$firstBlock];
@@ -1175,7 +1373,7 @@ class StreamingXlsxReader
         }
 
         $ranges = $this->blockRanges($index, $entry);
-        foreach ($this->mergeRuns($candidate) as [$firstBlock, $lastBlock]) {
+        foreach ($this->planRuns($candidate, $ranges, $this->maxBridgeBytes()) as [$firstBlock, $lastBlock]) {
             $start = $ranges[$firstBlock];
             $stopRow = $ranges[$lastBlock]['last_row'];
             $compLength = $this->runCompLength($ranges, $firstBlock, $lastBlock);
@@ -1361,7 +1559,7 @@ class StreamingXlsxReader
         }
 
         $ranges = $this->blockRanges($index, $entry);
-        $runs = $this->mergeRuns($candidate);
+        $runs = $this->planRuns($candidate, $ranges, $this->maxBridgeBytes());
         $bytes = 0;
         $upper = 0;
         foreach ($runs as [$firstBlock, $lastBlock]) {
@@ -1433,34 +1631,78 @@ class StreamingXlsxReader
 
     /**
      * Collapse an ascending list of surviving block indices into
-     * contiguous [firstBlock, lastBlock] runs, so each run costs one seek
-     * plus one linear scan instead of a seek per block. A gap in the
-     * indices (a pruned block between survivors) starts a new run.
+     * [firstBlock, lastBlock] runs, so each run costs one seek plus one
+     * linear scan instead of a seek per block. Adjacent survivors always
+     * merge; a gap of pruned blocks merges too (G5 gap-bridging) when its
+     * compressed byte span fits $maxBridgeBytes — the reader keeps one
+     * ranged read alive through the gap because transferring those bytes
+     * beats a fresh round-trip. The gap's non-matching rows are read and
+     * filtered out, never mismatched.
+     *
+     * $maxBridgeBytes = 0 (a zero-latency / no-hints Source) disables
+     * bridging entirely, so run merging is byte-for-byte the contiguous
+     * behaviour it always had.
      *
      * @param  list<int>  $blocks  ascending, no duplicates
+     * @param  list<array{first_row: int, last_row: int, comp_offset: int|null, uncomp_offset: int|null, start_row_at_offset: int|null}>  $ranges
      * @return list<array{0: int, 1: int}>
      */
-    private function mergeRuns(array $blocks): array
+    private function planRuns(array $blocks, array $ranges, int $maxBridgeBytes): array
     {
-        $runs = [];
-        $run = null;
-        $prev = null;
-        foreach ($blocks as $i) {
-            if ($run === null) {
-                $run = [$i, $i];
-            } elseif ($i === $prev + 1) {
-                $run[1] = $i;
-            } else {
-                $runs[] = $run;
-                $run = [$i, $i];
-            }
-            $prev = $i;
-        }
-        if ($run !== null) {
-            $runs[] = $run;
+        if ($blocks === []) {
+            return [];
         }
 
+        $runs = [];
+        $runStart = $blocks[0];
+        $runEnd = $blocks[0];
+        for ($i = 1, $n = count($blocks); $i < $n; $i++) {
+            $b = $blocks[$i];
+            if ($b === $runEnd + 1) {
+                $runEnd = $b;
+
+                continue;
+            }
+
+            // Gap = blocks [runEnd+1 .. b-1]; its compressed span is the
+            // distance between the sync point after runEnd and the one
+            // starting b. Bridge only when both offsets are known and the
+            // span fits the round-trip byte budget.
+            $gapFrom = $ranges[$runEnd + 1]['comp_offset'] ?? null;
+            $gapTo = $ranges[$b]['comp_offset'] ?? null;
+            $gapBytes = ($gapFrom !== null && $gapTo !== null) ? $gapTo - $gapFrom : PHP_INT_MAX;
+
+            if ($maxBridgeBytes > 0 && $gapBytes <= $maxBridgeBytes) {
+                $runEnd = $b; // bridge the gap into the current run
+            } else {
+                $runs[] = [$runStart, $runEnd];
+                $runStart = $b;
+                $runEnd = $b;
+            }
+        }
+        $runs[] = [$runStart, $runEnd];
+
         return $runs;
+    }
+
+    /**
+     * Byte budget for gap-bridging: how many compressed bytes transfer in
+     * one round-trip on this Source (rtt × bandwidth). A Source without
+     * ProvidesCostHints (local disk) is treated as zero-latency → 0 →
+     * bridging off. Memoized; the hints don't change within a read.
+     */
+    private function maxBridgeBytes(): int
+    {
+        if ($this->bridgeBytesCache === null) {
+            if ($this->source instanceof ProvidesCostHints) {
+                $h = $this->source->costHints();
+                $this->bridgeBytesCache = (int) (($h['rtt_us'] / 1_000_000) * $h['bandwidth_bps']);
+            } else {
+                $this->bridgeBytesCache = 0;
+            }
+        }
+
+        return $this->bridgeBytesCache;
     }
 
     /**

--- a/src/Sinks/S3MultipartSink.php
+++ b/src/Sinks/S3MultipartSink.php
@@ -53,6 +53,9 @@ class S3MultipartSink implements Sink
 
     private int $concurrency;
 
+    /** When true, each part carries a Content-MD5 so S3 rejects a corrupted part. */
+    private bool $verifyParts = false;
+
     private int $partNumber = 1;
 
     private int $bytesWritten = 0;
@@ -89,6 +92,11 @@ class S3MultipartSink implements Sink
      *        a higher, sawtooth memory profile than the synchronous default.
      *        Prefer it only when you have measured a throughput win on your
      *        link; on bandwidth-bound links it is no faster than the default.
+     * @param bool $verifyParts When true, every part carries a Content-MD5 so
+     *        S3 verifies each part's bytes and rejects a corrupted one — a
+     *        corrupt part never enters the object ("verified export", for
+     *        audit/payroll/HR data). Costs one MD5 per part (per ~part_size,
+     *        not per row). Default off.
      */
     public function __construct(
         S3Client $s3,
@@ -96,7 +104,8 @@ class S3MultipartSink implements Sink
         string $key,
         int $partSize = self::DEFAULT_PART_SIZE,
         array $putObjectParams = [],
-        ?int $concurrency = self::DEFAULT_CONCURRENCY
+        ?int $concurrency = self::DEFAULT_CONCURRENCY,
+        bool $verifyParts = false
     ) {
         $this->s3 = $s3;
         $this->bucket = $bucket;
@@ -105,6 +114,7 @@ class S3MultipartSink implements Sink
         // Silently adjust part size if too small
         $this->partSize = max(self::MIN_PART_SIZE, $partSize);
         $this->concurrency = max(1, $concurrency ?? self::DEFAULT_CONCURRENCY);
+        $this->verifyParts = $verifyParts;
 
         // Default parameters
         $this->putObjectParams = array_merge([
@@ -197,16 +207,37 @@ class S3MultipartSink implements Sink
      * to leak. The SDK's own retry middleware handles transient errors;
      * a hard failure is recorded like the async path's.
      */
+    /**
+     * Build uploadPart params, attaching a Content-MD5 when verifyParts is
+     * on so S3 recomputes the digest of the bytes it received and REJECTS
+     * the part on any mismatch — corrupt bytes never enter the object.
+     * (Content-MD5 is the header S3 has always enforced; the newer
+     * x-amz-checksum-* flexible checksums are not reliably verified by
+     * older SDKs, so MD5 is the portable per-part integrity guarantee.)
+     *
+     * @return array<string, mixed>
+     */
+    private function partParams(int $partNumber, string $chunk): array
+    {
+        $params = [
+            'Bucket' => $this->bucket,
+            'Key' => $this->key,
+            'UploadId' => $this->uploadId,
+            'PartNumber' => $partNumber,
+            'Body' => $chunk,
+        ];
+
+        if ($this->verifyParts) {
+            $params['ContentMD5'] = base64_encode(md5($chunk, true));
+        }
+
+        return $params;
+    }
+
     private function uploadPartSync(int $partNumber, string $chunk): void
     {
         try {
-            $result = $this->s3->uploadPart([
-                'Bucket' => $this->bucket,
-                'Key' => $this->key,
-                'UploadId' => $this->uploadId,
-                'PartNumber' => $partNumber,
-                'Body' => $chunk,
-            ]);
+            $result = $this->s3->uploadPart($this->partParams($partNumber, $chunk));
             $this->recordPart($partNumber, (string) $result['ETag']);
         } catch (\Throwable $e) {
             if ($this->failed === null) {
@@ -235,13 +266,7 @@ class S3MultipartSink implements Sink
      */
     private function sendPartAsync(int $partNumber, string $chunk): PromiseInterface
     {
-        $params = [
-            'Bucket' => $this->bucket,
-            'Key' => $this->key,
-            'UploadId' => $this->uploadId,
-            'PartNumber' => $partNumber,
-            'Body' => $chunk,
-        ];
+        $params = $this->partParams($partNumber, $chunk);
 
         return $this->s3->uploadPartAsync($params)->then(
             function ($result) use ($partNumber) {

--- a/src/Sinks/S3MultipartSink.php
+++ b/src/Sinks/S3MultipartSink.php
@@ -66,7 +66,7 @@ class S3MultipartSink implements Sink
 
     public const DEFAULT_PART_SIZE = 8388608; // 8MB
 
-    public const DEFAULT_CONCURRENCY = 4;
+    public const DEFAULT_CONCURRENCY = 1;
 
     /**
      * @param S3Client $s3
@@ -74,13 +74,21 @@ class S3MultipartSink implements Sink
      * @param string $key S3 object key (path)
      * @param int $partSize Size of each part (min 5MB)
      * @param array $putObjectParams Additional S3 parameters (ContentType, ACL, etc)
-     * @param int|null $concurrency Max part uploads in flight at once (default 4).
-     *        Parts are dispatched asynchronously; when the window is full the
-     *        writer waits for the oldest part before dispatching the next one.
-     *        Memory ceiling is roughly partSize x (concurrency + 1): up to
-     *        `concurrency` part bodies held by in-flight requests plus the
-     *        accumulating buffer. Use 1 for strictly sequential uploads
-     *        (same S3 request sequence as pre-3.2 versions).
+     * @param int|null $concurrency Max part uploads in flight at once.
+     *        DEFAULT 1 = strictly synchronous uploads: each part is sent and
+     *        released before the next is buffered, so memory stays flat at
+     *        ~partSize regardless of file size (true O(1), the streaming-to-S3
+     *        promise). This is the safe default.
+     *
+     *        concurrency > 1 opts into PARALLEL part uploads (async window):
+     *        it hides per-request latency on high-RTT links, but the AWS SDK's
+     *        async promise/command graph holds each in-flight part's body in a
+     *        reference cycle that plain refcounting can't free, so the working
+     *        set grows with the number of dispatched parts until a periodic
+     *        gc_collect_cycles() (issued at each part boundary) reclaims it —
+     *        a higher, sawtooth memory profile than the synchronous default.
+     *        Prefer it only when you have measured a throughput win on your
+     *        link; on bandwidth-bound links it is no faster than the default.
      */
     public function __construct(
         S3Client $s3,
@@ -163,6 +171,16 @@ class S3MultipartSink implements Sink
      */
     private function dispatchPart(string $chunk): void
     {
+        // Synchronous default: send the part and let its body be released
+        // immediately (no async promise graph to leak). Flat ~partSize memory.
+        if ($this->concurrency === 1) {
+            $this->uploadPartSync($this->partNumber, $chunk);
+            $this->partNumber++;
+
+            return;
+        }
+
+        // Parallel window (opt-in): bounded to `concurrency` in-flight parts.
         while (count($this->inFlight) >= $this->concurrency) {
             $this->awaitOldest();
             $this->throwIfFailed();
@@ -172,6 +190,38 @@ class S3MultipartSink implements Sink
         $this->partNumber++;
 
         $this->inFlight[$partNumber] = $this->sendPartAsync($partNumber, $chunk);
+    }
+
+    /**
+     * Upload one part synchronously — no async promise, so nothing lingers
+     * to leak. The SDK's own retry middleware handles transient errors;
+     * a hard failure is recorded like the async path's.
+     */
+    private function uploadPartSync(int $partNumber, string $chunk): void
+    {
+        try {
+            $result = $this->s3->uploadPart([
+                'Bucket' => $this->bucket,
+                'Key' => $this->key,
+                'UploadId' => $this->uploadId,
+                'PartNumber' => $partNumber,
+                'Body' => $chunk,
+            ]);
+            $this->recordPart($partNumber, (string) $result['ETag']);
+        } catch (\Throwable $e) {
+            if ($this->failed === null) {
+                $this->failed = S3Exception::partUploadFailed($partNumber, $e->getMessage());
+            }
+        }
+
+        // The SDK's uploadPart is uploadPartAsync()->wait() under the hood, so
+        // even this synchronous call leaves the part's ~partSize body in a
+        // settled-promise reference cycle. Collecting it here — once per part,
+        // a handful of times per GB — keeps memory flat at ~partSize (true
+        // O(1)) instead of climbing toward the whole file. Measured cost is a
+        // few ms across a multi-GB upload; negligible against the network.
+        unset($result);
+        gc_collect_cycles();
     }
 
     /**
@@ -262,6 +312,15 @@ class S3MultipartSink implements Sink
         // The fulfillment handler normally removes the entry; make sure a
         // settled promise never lingers in the window.
         unset($this->inFlight[$oldest]);
+        unset($promise);
+
+        // Parallel path only. The AWS SDK's async promise/command graph links
+        // each settled request into a reference cycle that holds the part's
+        // body; refcounting can't free it, so without this the working set
+        // climbs toward the whole file. Collecting at each part boundary (a
+        // handful of times per GB) caps it. The synchronous default never
+        // reaches here and needs no GC.
+        gc_collect_cycles();
     }
 
     /**

--- a/src/Sinks/S3MultipartSink.php
+++ b/src/Sinks/S3MultipartSink.php
@@ -247,10 +247,16 @@ class S3MultipartSink implements Sink
 
         // The SDK's uploadPart is uploadPartAsync()->wait() under the hood, so
         // even this synchronous call leaves the part's ~partSize body in a
-        // settled-promise reference cycle. Collecting it here — once per part,
-        // a handful of times per GB — keeps memory flat at ~partSize (true
-        // O(1)) instead of climbing toward the whole file. Measured cost is a
-        // few ms across a multi-GB upload; negligible against the network.
+        // settled-promise reference cycle. Refcounting can't reclaim a cycle
+        // and PHP's automatic collector won't fire until ~10k roots accrue —
+        // thousands of parts later — so without this the bodies pile up and
+        // memory climbs toward the whole file (a 128 MB process OOMs at ~16
+        // parts). One collection per part keeps it flat at ~partSize (true
+        // O(1)). It is cheap: the collector scans only the root buffer (the
+        // handful of cycle objects a settled part leaves, not the live heap),
+        // measured a few ms of GC work across a multi-GB upload; the ~partSize
+        // free it triggers is work owed regardless. Once per 8 MB PUT, never
+        // on a hot inner loop.
         unset($result);
         gc_collect_cycles();
     }

--- a/src/Sketches/TDigest.php
+++ b/src/Sketches/TDigest.php
@@ -250,6 +250,70 @@ class TDigest
         return $prevValue + ($this->max - $prevValue) * ($index - $prevMid) / ($this->count - $prevMid);
     }
 
+    /**
+     * Approximate CDF: fraction of the stream's values <= $x — the inverse
+     * of quantile(). null for an empty digest; 0.0 below min, 1.0 above
+     * max. A single O(centroids) pass through the same piecewise-linear
+     * model quantile() uses, so rank() and quantile() are numerical
+     * inverses within the digest's resolution:
+     *
+     *     rank(quantile(q)) ≈ q    and    quantile(rank(x)) ≈ x
+     *
+     * This is the direct CDF the reader's selectivity estimator needs;
+     * previously it recovered the CDF by bisecting quantile() 40 times
+     * (40 × O(centroids) → one O(centroids) pass here, ~80× fewer calls
+     * into the centroid walk for a 'between' estimate).
+     */
+    public function rank(float $x): ?float
+    {
+        $this->flushBuffer();
+
+        if ($this->count === 0) {
+            return null;
+        }
+        // Boundary conventions mirror quantile()'s early returns: x at/below
+        // min → 0.0 (the rank of the first value), x at/above max → 1.0.
+        if ($x <= $this->min) {
+            return 0.0;
+        }
+        if ($x >= $this->max) {
+            return 1.0;
+        }
+
+        // Walk centroid midpoints exactly as quantile() does, but solve for
+        // the rank whose quantile would land at x. Centroid i sits at the
+        // cumulative-weight midpoint m_i; the value segment between the
+        // previous anchor and mean_i maps linearly onto the rank segment
+        // [prevMid, m_i]. Head anchor (min, 0), tail (max, count).
+        //
+        // Whenever $x < $mean triggers we have prevValue <= x < mean, so
+        // $mean > $prevValue strictly — the interpolation denominator is
+        // always positive (no degenerate-segment guard needed).
+        $cumBefore = 0.0;
+        $prevMid = 0.0;
+        $prevValue = $this->min;
+
+        foreach ($this->means as $i => $mean) {
+            $mid = $cumBefore + $this->weights[$i] / 2;
+            if ($x < $mean) {
+                $index = $prevMid + ($mid - $prevMid) * ($x - $prevValue) / ($mean - $prevValue);
+
+                return $index / $this->count;
+            }
+            $cumBefore += $this->weights[$i];
+            $prevMid = $mid;
+            $prevValue = $mean;
+        }
+
+        // Tail segment [prevValue, max] → rank [prevMid, count]. We reach
+        // here only when x >= every centroid mean; x < max (guarded above),
+        // and max > prevValue (the last centroid does not saturate at max
+        // unless min === max, which the early return handled).
+        $index = $prevMid + ($this->count - $prevMid) * ($x - $prevValue) / ($this->max - $prevValue);
+
+        return $index / $this->count;
+    }
+
     public function count(): int
     {
         return $this->count;

--- a/src/Sources/LocalFileSource.php
+++ b/src/Sources/LocalFileSource.php
@@ -3,6 +3,7 @@
 namespace Kolay\XlsxStream\Sources;
 
 use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Contracts\SupportsBoundedStream;
 use Kolay\XlsxStream\Contracts\SupportsSuffixRange;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
 
@@ -13,7 +14,7 @@ use Kolay\XlsxStream\Exceptions\XlsxReadException;
  * a fresh handle per streamFrom() call so the parser's long-running
  * sequential read does not interfere with central-directory lookups.
  */
-class LocalFileSource implements Source, SupportsSuffixRange
+class LocalFileSource implements Source, SupportsBoundedStream, SupportsSuffixRange
 {
     /** @var resource */
     private $handle;
@@ -80,15 +81,10 @@ class LocalFileSource implements Source, SupportsSuffixRange
         ];
     }
 
-    public function streamFrom(int $offset, ?int $length = null)
+    public function streamFrom(int $offset)
     {
         $this->guardOpen();
 
-        // $length is ignored: local fread is lazy and the sheet reader
-        // already caps how many compressed bytes it pulls (bounded scans
-        // stop at a sync boundary via inflatedChunks' compLength), so a
-        // plain seeked handle over-reads nothing. Bounding only pays on
-        // remote sources where the range is an HTTP fetch size.
         $h = @fopen($this->path, 'rb');
         if ($h === false) {
             throw XlsxReadException::sourceUnreadable("cannot reopen file: {$this->path}");
@@ -100,6 +96,16 @@ class LocalFileSource implements Source, SupportsSuffixRange
         }
 
         return $h;
+    }
+
+    public function streamFromRange(int $offset, int $length)
+    {
+        // Local reads are lazy and the sheet reader already caps how many
+        // compressed bytes it pulls (a bounded scan stops at a sync
+        // boundary), so a plain seeked handle over-reads nothing on disk —
+        // $length needs no special handling here. Bounding only pays on
+        // remote sources where the range is an actual HTTP fetch size.
+        return $this->streamFrom($offset);
     }
 
     public function close(): void

--- a/src/Sources/LocalFileSource.php
+++ b/src/Sources/LocalFileSource.php
@@ -80,10 +80,15 @@ class LocalFileSource implements Source, SupportsSuffixRange
         ];
     }
 
-    public function streamFrom(int $offset)
+    public function streamFrom(int $offset, ?int $length = null)
     {
         $this->guardOpen();
 
+        // $length is ignored: local fread is lazy and the sheet reader
+        // already caps how many compressed bytes it pulls (bounded scans
+        // stop at a sync boundary via inflatedChunks' compLength), so a
+        // plain seeked handle over-reads nothing. Bounding only pays on
+        // remote sources where the range is an HTTP fetch size.
         $h = @fopen($this->path, 'rb');
         if ($h === false) {
             throw XlsxReadException::sourceUnreadable("cannot reopen file: {$this->path}");

--- a/src/Sources/S3RangeSource.php
+++ b/src/Sources/S3RangeSource.php
@@ -122,15 +122,22 @@ class S3RangeSource implements Source, SupportsSuffixRange
         return ['data' => $data, 'size' => $size];
     }
 
-    public function streamFrom(int $offset)
+    public function streamFrom(int $offset, ?int $length = null)
     {
         $size = $this->size();
+
+        // Bounded scans stop at a sync boundary: fetch exactly
+        // [offset, offset+length-1] instead of streaming to EOF, so a
+        // pruned query over an early block reads only that block's bytes
+        // off the wire. Clamp to the last byte so a length past EOF (or
+        // null) degrades to the historical open-ended range.
+        $end = $length !== null ? min($offset + $length - 1, $size - 1) : $size - 1;
 
         try {
             $r = $this->s3->getObject([
                 'Bucket' => $this->bucket,
                 'Key' => $this->key,
-                'Range' => sprintf('bytes=%d-%d', $offset, $size - 1),
+                'Range' => sprintf('bytes=%d-%d', $offset, $end),
                 '@http' => ['stream' => true],
             ]);
         } catch (\Throwable $e) {

--- a/src/Sources/S3RangeSource.php
+++ b/src/Sources/S3RangeSource.php
@@ -6,6 +6,7 @@ use Aws\S3\S3Client;
 use GuzzleHttp\Psr7\StreamWrapper;
 use Kolay\XlsxStream\Contracts\ProvidesCostHints;
 use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Contracts\SupportsBoundedStream;
 use Kolay\XlsxStream\Contracts\SupportsSuffixRange;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
 
@@ -20,7 +21,7 @@ use Kolay\XlsxStream\Exceptions\XlsxReadException;
  * getObject call — without it the SDK spills bodies >2 MB to php://temp,
  * which would defeat the bounded-memory goal of the reader.
  */
-class S3RangeSource implements ProvidesCostHints, Source, SupportsSuffixRange
+class S3RangeSource implements ProvidesCostHints, Source, SupportsBoundedStream, SupportsSuffixRange
 {
     private S3Client $s3;
     private string $bucket;
@@ -144,17 +145,27 @@ class S3RangeSource implements ProvidesCostHints, Source, SupportsSuffixRange
         return ['data' => $data, 'size' => $size];
     }
 
-    public function streamFrom(int $offset, ?int $length = null)
+    public function streamFrom(int $offset)
     {
-        $size = $this->size();
+        return $this->rangedStream($offset, $this->size() - 1);
+    }
 
+    public function streamFromRange(int $offset, int $length)
+    {
         // Bounded scans stop at a sync boundary: fetch exactly
         // [offset, offset+length-1] instead of streaming to EOF, so a
         // pruned query over an early block reads only that block's bytes
-        // off the wire. Clamp to the last byte so a length past EOF (or
-        // null) degrades to the historical open-ended range.
-        $end = $length !== null ? min($offset + $length - 1, $size - 1) : $size - 1;
+        // off the wire. Clamp to the last byte in case length runs past EOF.
+        return $this->rangedStream($offset, min($offset + $length - 1, $this->size() - 1));
+    }
 
+    /**
+     * Open a streaming ranged GET for [offset, end] (inclusive).
+     *
+     * @return resource
+     */
+    private function rangedStream(int $offset, int $end)
+    {
         try {
             $r = $this->s3->getObject([
                 'Bucket' => $this->bucket,

--- a/src/Sources/S3RangeSource.php
+++ b/src/Sources/S3RangeSource.php
@@ -4,6 +4,7 @@ namespace Kolay\XlsxStream\Sources;
 
 use Aws\S3\S3Client;
 use GuzzleHttp\Psr7\StreamWrapper;
+use Kolay\XlsxStream\Contracts\ProvidesCostHints;
 use Kolay\XlsxStream\Contracts\Source;
 use Kolay\XlsxStream\Contracts\SupportsSuffixRange;
 use Kolay\XlsxStream\Exceptions\XlsxReadException;
@@ -19,18 +20,39 @@ use Kolay\XlsxStream\Exceptions\XlsxReadException;
  * getObject call — without it the SDK spills bodies >2 MB to php://temp,
  * which would defeat the bounded-memory goal of the reader.
  */
-class S3RangeSource implements Source, SupportsSuffixRange
+class S3RangeSource implements ProvidesCostHints, Source, SupportsSuffixRange
 {
     private S3Client $s3;
     private string $bucket;
     private string $key;
     private ?int $size = null;
+    private int $rttUs;
+    private int $bandwidthBps;
 
-    public function __construct(S3Client $s3, string $bucket, string $key)
-    {
+    /**
+     * $rttUs / $bandwidthBps are gap-bridging planning hints (see
+     * ProvidesCostHints), not benchmark claims — override them for your
+     * deployment. Defaults are conservative intra-region estimates
+     * (~30 ms round-trip, ~50 MB/s per connection); they only affect how
+     * aggressively pruned scans coalesce runs, never correctness.
+     */
+    public function __construct(
+        S3Client $s3,
+        string $bucket,
+        string $key,
+        int $rttUs = 30_000,
+        int $bandwidthBps = 52_428_800
+    ) {
         $this->s3 = $s3;
         $this->bucket = $bucket;
         $this->key = $key;
+        $this->rttUs = $rttUs;
+        $this->bandwidthBps = $bandwidthBps;
+    }
+
+    public function costHints(): array
+    {
+        return ['rtt_us' => $this->rttUs, 'bandwidth_bps' => $this->bandwidthBps];
     }
 
     public function size(): int

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -194,6 +194,13 @@ abstract class BaseXlsxWriter
     protected int $indexSyncPeriod = 10000;
     protected int $rowsSinceSync = 0;
 
+    // Group-boundary sync (opt-in via syncAtGroupBoundaries). When set,
+    // a ZLIB_FULL_FLUSH is forced whenever the 1-based $groupSyncColumn's
+    // value changes, so each index block holds exactly one group and
+    // groupStats() folds it straight from the sidecar with zero row reads.
+    protected ?int $groupSyncColumn = null;
+    protected ?string $lastGroupKey = null;
+
     /**
      * Per-sheet sync points keyed by sheet entry path.
      *
@@ -430,6 +437,41 @@ abstract class BaseXlsxWriter
 
         $this->randomAccessIndexEnabled = true;
         $this->indexSyncPeriod = $every;
+
+        return $this;
+    }
+
+    /**
+     * Align index block boundaries to GROUP changes: force a sync point
+     * (ZLIB_FULL_FLUSH) whenever the 1-based $column's value differs from
+     * the previous row's, so each block holds exactly one group.
+     *
+     * Why it pays: groupStats() folds a group-pure block straight from the
+     * sidecar's per-block aggregates without reading a row. Aligning
+     * blocks to groups makes EVERY block pure, so "GROUP BY on a grouped
+     * export" answers from the sidecar alone — zero row reads, even on S3.
+     * Pair it with withColumnStats() on the group and aggregate columns.
+     *
+     * Rows must be written grouped (all of a group's rows consecutive),
+     * as grouped exports already are; an interleaved column just produces
+     * more, smaller blocks (still correct). Enables the random-access
+     * index if it is not already on. Must be called before startFile().
+     * The row-count sync period still applies as an upper bound, so a
+     * single huge group is capped into several (same-group) blocks.
+     */
+    public function syncAtGroupBoundaries(int $column): self
+    {
+        if ($this->started) {
+            throw XlsxStreamException::alreadyStarted();
+        }
+        if ($column < 1) {
+            throw new XlsxStreamException(
+                "Group-sync column is 1-based; got {$column}."
+            );
+        }
+
+        $this->groupSyncColumn = $column;
+        $this->randomAccessIndexEnabled = true;
 
         return $this;
     }
@@ -932,6 +974,21 @@ abstract class BaseXlsxWriter
             $this->startNewSheet();
         }
 
+        // Group-boundary sync: when this row starts a new group, flush the
+        // buffered previous group WITH a sync point so its block ends here.
+        // Runs before currentSheetRow++ so the sync point (recorded as
+        // currentSheetRow + 1) lands on this row — the first of the new
+        // group's block. The empty-buffer guard skips the first row and
+        // fresh-sheet starts.
+        if ($this->groupSyncColumn !== null) {
+            $value = $row[$this->groupSyncColumn - 1] ?? null;
+            $key = is_scalar($value) ? (string) $value : '';
+            if ($this->lastGroupKey !== null && $key !== $this->lastGroupKey && $this->rowBuffer !== '') {
+                $this->flushRowBuffer(true);
+            }
+            $this->lastGroupKey = $key;
+        }
+
         $this->currentSheetRow++;
         $this->totalRows++;
 
@@ -1195,7 +1252,7 @@ abstract class BaseXlsxWriter
      * elements, the alignment invariant the reader's row tokenizer
      * depends on.
      */
-    protected function flushRowBuffer(): void
+    protected function flushRowBuffer(bool $forceSync = false): void
     {
         if ($this->rowBuffer === '') {
             return;
@@ -1203,7 +1260,7 @@ abstract class BaseXlsxWriter
 
         $rowsInBuffer = $this->rowBufferCount;
         $shouldSync = $this->randomAccessIndexEnabled
-            && ($this->rowsSinceSync + $rowsInBuffer) >= $this->indexSyncPeriod;
+            && ($forceSync || ($this->rowsSinceSync + $rowsInBuffer) >= $this->indexSyncPeriod);
 
         if (! $shouldSync) {
             $this->writeSheetData($this->rowBuffer);

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -106,6 +106,7 @@ abstract class BaseXlsxWriter
     // Writer state
     protected bool $started = false;
     protected bool $closed = false;
+    protected bool $compactMode = false;
 
     // Performance optimizations
     protected int $bufferFlushInterval = 1000;
@@ -189,6 +190,7 @@ abstract class BaseXlsxWriter
     // $indexSyncPeriod rows, and an xl/_kxs/index.bin sidecar is written on
     // finishFile(). Default off — every previously-written byte is identical.
     protected bool $randomAccessIndexEnabled = false;
+
     protected int $indexSyncPeriod = 10000;
     protected int $rowsSinceSync = 0;
 
@@ -355,6 +357,47 @@ abstract class BaseXlsxWriter
             throw XlsxStreamException::invalidCompressionLevel($level);
         }
         $this->deflateLevel = $level;
+        return $this;
+    }
+
+    /**
+     * Opt in to COMPACT output: rows and cells are written WITHOUT the
+     * r attribute. ECMA-376 declares both c/@r and row/@r optional —
+     * readers assign positions sequentially when they are absent, which
+     * is why empty cells still emit a `<c/>` placeholder (the
+     * placeholder IS the position carrier; see the compact row
+     * builders).
+     *
+     * Why it pays: `r="AB123456"` is a UNIQUE string per cell — high-
+     * entropy noise deflate cannot back-reference. Dropping it turns
+     * the row body into a near-pure template. Measured on this machine
+     * (100K-row mixed workload, apple-to-apple; ratios vary with data
+     * shape): compressed sheet bytes −52 % (up to ~−62 % on sparse
+     * data), writing −26 % and reading −33 % faster — the smaller XML
+     * is quicker to both build and tokenize.
+     *
+     * Interoperability, verified per this package's real-app testing
+     * discipline: Microsoft Excel, LibreOffice and Apple Numbers open
+     * compact files (manual tests, styles/formats/freeze/autofilter
+     * included); PhpSpreadsheet 5.8 and OpenSpout 4.28 read them
+     * correctly — both implement sequential fallback as first-class
+     * code paths — and this package's own reader never consumed r in
+     * the first place. Still opt-in while the mode accumulates field
+     * mileage; classic output remains byte-identical when off.
+     *
+     * Must be called before startFile(): flipping mid-sheet would mix
+     * referenced and sequential cells and corrupt position assignment.
+     */
+    public function compact(bool $enabled = true): self
+    {
+        if ($this->closed) {
+            throw XlsxStreamException::writerAlreadyClosed();
+        }
+        if ($this->started) {
+            throw XlsxStreamException::alreadyStarted();
+        }
+        $this->compactMode = $enabled;
+
         return $this;
     }
 
@@ -1680,11 +1723,21 @@ abstract class BaseXlsxWriter
 
         if (! empty($this->columns)) {
             $headerStyleAttr = $this->headerStyleId !== null ? ' s="'.$this->headerStyleId.'"' : '';
-            $headerRow = '<row r="1">';
-            foreach ($this->columns as $i => $header) {
-                $cellRef = $this->getColumnLetter($i + 1).'1';
-                $escaped = $this->fastXmlEscape((string) $header);
-                $headerRow .= '<c r="'.$cellRef.'"'.$headerStyleAttr.' t="inlineStr"><is><t>'.$escaped.'</t></is></c>';
+            // Compact mode drops the optional r attributes here too —
+            // once per sheet, so a plain conditional (not a twin) does.
+            if ($this->compactMode) {
+                $headerRow = '<row>';
+                foreach ($this->columns as $header) {
+                    $escaped = $this->fastXmlEscape((string) $header);
+                    $headerRow .= '<c'.$headerStyleAttr.' t="inlineStr"><is><t>'.$escaped.'</t></is></c>';
+                }
+            } else {
+                $headerRow = '<row r="1">';
+                foreach ($this->columns as $i => $header) {
+                    $cellRef = $this->getColumnLetter($i + 1).'1';
+                    $escaped = $this->fastXmlEscape((string) $header);
+                    $headerRow .= '<c r="'.$cellRef.'"'.$headerStyleAttr.' t="inlineStr"><is><t>'.$escaped.'</t></is></c>';
+                }
             }
             $headerRow .= '</row>';
             $xml .= $headerRow;
@@ -1932,6 +1985,15 @@ abstract class BaseXlsxWriter
      */
     protected function buildRowXml(int $rowIndex, array $data, ?int $rowStyleId = null): string
     {
+        // Compact dispatch first: one boolean test per row is the whole
+        // price on the classic path (the tokenizer date-twin pattern —
+        // the two shapes share no hot loop, so neither taxes the other).
+        if ($this->compactMode) {
+            return $rowStyleId !== null
+                ? $this->buildStyledRowXmlCompact($data, $rowStyleId)
+                : $this->buildRowXmlCompact($data);
+        }
+
         if ($rowStyleId !== null) {
             return $this->buildStyledRowXml($rowIndex, $data, $rowStyleId);
         }
@@ -2144,6 +2206,187 @@ abstract class BaseXlsxWriter
                 $xml .= '<c r="' . $cellRef . '"' . $sAttr . ' t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
             } else {
                 $xml .= '<c r="' . $cellRef . '"' . $sAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+            }
+        }
+
+        return $xml . '</row>';
+    }
+
+    /**
+     * Compact (r-less) twin of buildRowXml — see compact(). Every branch
+     * is the exact projection of its classic counterpart with the
+     * ` r="A1"` attribute removed; the transform byte-oracle test pins
+     * that equivalence, so the two builders cannot drift apart.
+     *
+     * No cell references means no column-letter cache fill and no
+     * per-cell letters/rowIndex concatenation — the branch bodies are
+     * otherwise IDENTICAL to the classic builder. Empty cells still
+     * emit `<c/>`: with sequential position assignment the placeholder
+     * IS the position carrier, dropping it would shift every later
+     * cell left.
+     */
+    protected function buildRowXmlCompact(array $data): string
+    {
+        $columnStyleIds = $this->columnStyleIds;
+        $hasColumnStyles = ! empty($columnStyleIds);
+
+        $xml = '<row>';
+        $col = 0;
+
+        foreach ($data as $value) {
+            ++$col;
+
+            if (is_string($value)) {
+                if ($value === '') {
+                    $xml .= '<c/>';
+                    continue;
+                }
+
+                if (is_numeric($value)) {
+                    if ($this->shouldPreserveNumericString($value)) {
+                        $xml .= '<c t="inlineStr"><is><t>' . $this->fastXmlEscape($value) . '</t></is></c>';
+                    } elseif ($hasColumnStyles && isset($columnStyleIds[$col])) {
+                        $xml .= '<c s="' . $columnStyleIds[$col] . '" t="n"><v>' . (0 + $value) . '</v></c>';
+                    } else {
+                        $xml .= '<c t="n"><v>' . (0 + $value) . '</v></c>';
+                    }
+                    continue;
+                }
+
+                $escaped = $this->fastXmlEscape($value);
+                if ($escaped !== '' && ($escaped[0] === ' ' || $escaped[0] === "\t" ||
+                    $escaped[strlen($escaped) - 1] === ' ' || $escaped[strlen($escaped) - 1] === "\t")) {
+                    $xml .= '<c t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
+                } else {
+                    $xml .= '<c t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+                }
+                continue;
+            }
+
+            if (is_int($value) || is_float($value)) {
+                if ($hasColumnStyles && isset($columnStyleIds[$col])) {
+                    $xml .= '<c s="' . $columnStyleIds[$col] . '" t="n"><v>' . $value . '</v></c>';
+                } else {
+                    $xml .= '<c t="n"><v>' . $value . '</v></c>';
+                }
+                continue;
+            }
+
+            if ($value === null) {
+                $xml .= '<c/>';
+                continue;
+            }
+
+            if (is_bool($value)) {
+                $xml .= '<c t="b"><v>' . ($value ? 1 : 0) . '</v></c>';
+                continue;
+            }
+
+            if ($value instanceof \DateTimeInterface) {
+                $serial = ($value->getTimestamp() - self::EXCEL_EPOCH_TIMESTAMP) / 86400;
+                $styleId = $hasColumnStyles && isset($columnStyleIds[$col])
+                    ? $columnStyleIds[$col]
+                    : self::STYLE_DATETIME;
+                $xml .= '<c s="' . $styleId . '" t="n"><v>' . $serial . '</v></c>';
+                continue;
+            }
+
+            $escaped = $this->fastXmlEscape((string) $value);
+
+            if ($escaped !== '' && ($escaped[0] === ' ' || $escaped[0] === "\t" ||
+                $escaped[strlen($escaped) - 1] === ' ' || $escaped[strlen($escaped) - 1] === "\t")) {
+                $xml .= '<c t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
+            } else {
+                $xml .= '<c t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+            }
+        }
+
+        return $xml . '</row>';
+    }
+
+    /**
+     * Compact (r-less) twin of buildStyledRowXml — same projection rule
+     * and byte-oracle pin as buildRowXmlCompact. Styled empty cells keep
+     * their `<c s="N"/>` placeholder for the same position-carrier
+     * reason.
+     */
+    protected function buildStyledRowXmlCompact(array $data, int $rowStyleId): string
+    {
+        $columnStyleIds = $this->columnStyleIds;
+        $hasColumnStyles = ! empty($columnStyleIds);
+        $sAttr = ' s="' . $rowStyleId . '"';
+
+        $xml = '<row>';
+        $col = 0;
+
+        foreach ($data as $value) {
+            ++$col;
+
+            if (is_string($value)) {
+                if ($value === '') {
+                    $xml .= '<c' . $sAttr . '/>';
+                    continue;
+                }
+
+                if (is_numeric($value)) {
+                    if ($this->shouldPreserveNumericString($value)) {
+                        $xml .= '<c' . $sAttr . ' t="inlineStr"><is><t>' . $this->fastXmlEscape($value) . '</t></is></c>';
+                    } elseif ($hasColumnStyles && isset($columnStyleIds[$col])) {
+                        $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $columnStyleIds[$col]);
+                        $xml .= '<c s="' . $styleId . '" t="n"><v>' . (0 + $value) . '</v></c>';
+                    } else {
+                        $xml .= '<c' . $sAttr . ' t="n"><v>' . (0 + $value) . '</v></c>';
+                    }
+                    continue;
+                }
+
+                $escaped = $this->fastXmlEscape($value);
+                if ($escaped !== '' && ($escaped[0] === ' ' || $escaped[0] === "\t" ||
+                    $escaped[strlen($escaped) - 1] === ' ' || $escaped[strlen($escaped) - 1] === "\t")) {
+                    $xml .= '<c' . $sAttr . ' t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
+                } else {
+                    $xml .= '<c' . $sAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
+                }
+                continue;
+            }
+
+            if (is_int($value) || is_float($value)) {
+                if ($hasColumnStyles && isset($columnStyleIds[$col])) {
+                    $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $columnStyleIds[$col]);
+                    $xml .= '<c s="' . $styleId . '" t="n"><v>' . $value . '</v></c>';
+                } else {
+                    $xml .= '<c' . $sAttr . ' t="n"><v>' . $value . '</v></c>';
+                }
+                continue;
+            }
+
+            if ($value === null) {
+                $xml .= '<c' . $sAttr . '/>';
+                continue;
+            }
+
+            if (is_bool($value)) {
+                $xml .= '<c' . $sAttr . ' t="b"><v>' . ($value ? 1 : 0) . '</v></c>';
+                continue;
+            }
+
+            if ($value instanceof \DateTimeInterface) {
+                $serial = ($value->getTimestamp() - self::EXCEL_EPOCH_TIMESTAMP) / 86400;
+                $columnStyleId = $hasColumnStyles && isset($columnStyleIds[$col])
+                    ? $columnStyleIds[$col]
+                    : self::STYLE_DATETIME;
+                $styleId = $this->mergeRowStyleWithColumnStyle($rowStyleId, $columnStyleId);
+                $xml .= '<c s="' . $styleId . '" t="n"><v>' . $serial . '</v></c>';
+                continue;
+            }
+
+            $escaped = $this->fastXmlEscape((string) $value);
+
+            if ($escaped !== '' && ($escaped[0] === ' ' || $escaped[0] === "\t" ||
+                $escaped[strlen($escaped) - 1] === ' ' || $escaped[strlen($escaped) - 1] === "\t")) {
+                $xml .= '<c' . $sAttr . ' t="inlineStr"><is><t xml:space="preserve">' . $escaped . '</t></is></c>';
+            } else {
+                $xml .= '<c' . $sAttr . ' t="inlineStr"><is><t>' . $escaped . '</t></is></c>';
             }
         }
 

--- a/src/Writers/BaseXlsxWriter.php
+++ b/src/Writers/BaseXlsxWriter.php
@@ -591,6 +591,27 @@ abstract class BaseXlsxWriter
         return $this;
     }
 
+    /**
+     * One-call preset for a fully queryable export: turn on the
+     * random-access index, per-block zone maps (columnStats) and, unless
+     * $withSketches is false, the t-digest/HLL sketches — all for the
+     * given 1-based $columns. Equivalent to chaining withRandomAccessIndex()
+     * + withColumnStats() + withColumnSketches(), and byte-identical to
+     * doing so with the same arguments.
+     *
+     * Must be called before startFile().
+     */
+    public function queryable(array $columns, int $every = 10000, bool $withSketches = true): self
+    {
+        $this->withRandomAccessIndex($every);
+        $this->withColumnStats($columns);
+        if ($withSketches) {
+            $this->withColumnSketches($columns);
+        }
+
+        return $this;
+    }
+
     public function setBufferFlushInterval(int $rows): self
     {
         if ($rows < 1) {

--- a/tests/Readers/BoundedStreamTest.php
+++ b/tests/Readers/BoundedStreamTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Sources\LocalFileSource;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * G6 — bounded streamFrom(offset, ?length).
+ *
+ * A pruned query that scans a NON-terminal run of blocks must open the
+ * sheet stream with a byte length that stops at the run's trailing sync
+ * point instead of ranging to the entry's end. On S3 this turns an
+ * open-ended [offset, EOF] GET into an exact [offset, offset+length-1]
+ * fetch; on local files it caps the inflate read. The rows returned must
+ * be byte-for-byte the full-scan oracle's rows — bounding is an I/O
+ * optimization, never a correctness change.
+ *
+ * The load-bearing gate is the byte-oracle: bounded reads end at a
+ * ZLIB_FULL_FLUSH sync boundary, so the inflate stream is fed to that
+ * boundary with NO_FLUSH and stopped WITHOUT a ZLIB_FINISH step (the
+ * flush already emitted every row up to it — the exact inverse of the
+ * seek-to-sync-point entry the random-access index already relies on).
+ */
+class BoundedStreamTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-bounded-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /** 2000 rows, sync every 100 -> ~20 blocks; col 1 ascending. */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'amount', 'name']);
+        for ($i = 1; $i <= 2000; $i++) {
+            $writer->writeRow([$i, round($i * 1.25, 2), 'name-'.$i]);
+        }
+        $writer->finishFile();
+    }
+
+    /** Spy Source recording every (offset, length) passed to streamFrom. */
+    private function makeSpy(): object
+    {
+        return new class (new LocalFileSource($this->testFile)) implements Source {
+            /** @var list<array{offset: int, length: int|null}> */
+            public array $streamCalls = [];
+
+            public function __construct(private LocalFileSource $inner) {}
+
+            public function size(): int
+            {
+                return $this->inner->size();
+            }
+
+            public function range(int $offset, int $length): string
+            {
+                return $this->inner->range($offset, $length);
+            }
+
+            public function streamFrom(int $offset, ?int $length = null)
+            {
+                $this->streamCalls[] = ['offset' => $offset, 'length' => $length];
+
+                return $this->inner->streamFrom($offset, $length);
+            }
+
+            public function close(): void
+            {
+                $this->inner->close();
+            }
+        };
+    }
+
+    public function test_non_terminal_run_is_fetched_with_a_bounded_length(): void
+    {
+        $this->writeFixture();
+        $spy = $this->makeSpy();
+        $reader = StreamingXlsxReader::from($spy);
+
+        // id in [200, 300] lives in early blocks — the run does NOT reach
+        // the last block, so the fetch must be bounded.
+        $hits = iterator_to_array($reader->rowsWhere(1, 'between', 200, 300));
+
+        $this->assertSame(range(200, 300), array_map(fn ($r) => (int) $r[0], array_values($hits)));
+
+        $bounded = array_filter($spy->streamCalls, fn ($c) => $c['length'] !== null);
+        $this->assertNotEmpty($bounded, 'a non-terminal pruned run must pass a bounded length to streamFrom');
+
+        // The bound must be strictly smaller than "from offset to entry end".
+        $size = $spy->size();
+        foreach ($bounded as $c) {
+            $this->assertLessThan($size - $c['offset'], $c['length'], 'bounded length should stop before EOF');
+            $this->assertGreaterThan(0, $c['length']);
+        }
+        $reader->close();
+    }
+
+    public function test_bounded_rows_equal_unbounded_oracle(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        // Oracle: brute-force filter over a full scan.
+        $oracle = [];
+        foreach ($reader->rows() as $row) {
+            $v = (float) ($row[0] ?? 0);
+            if ($v >= 200 && $v <= 300) {
+                $oracle[] = $row;
+            }
+        }
+
+        $pruned = iterator_to_array($reader->rowsWhere(1, 'between', 200, 300), false);
+        $this->assertSame($oracle, $pruned, 'bounded pruned scan must equal the full-scan oracle');
+        $reader->close();
+    }
+
+    public function test_tail_query_stays_correct_under_bounding(): void
+    {
+        // A run reaching the last DATA block is still bounded to the final
+        // sync point (the trailing zero-count block fails the count>0
+        // survivor test, so the run stops just before it) — which is only
+        // ever a tighter fetch. Correctness must hold regardless: the tail
+        // rows come back exactly, byte-for-byte with the full-scan oracle.
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $oracle = [];
+        foreach ($reader->rows() as $row) {
+            if ((float) ($row[0] ?? 0) >= 1990) {
+                $oracle[] = $row;
+            }
+        }
+
+        $pruned = iterator_to_array($reader->rowsWhere(1, '>=', 1990), false);
+        $this->assertSame($oracle, $pruned);
+        $this->assertSame(range(1990, 2000), array_map(fn ($r) => (int) $r[0], $pruned));
+        $reader->close();
+    }
+
+    public function test_full_scan_reads_to_eof_unbounded(): void
+    {
+        // The FINISH path (read to entry end) must be preserved for full
+        // scans: rows() passes no offset and no length, so every stream is
+        // opened unbounded exactly as before this feature.
+        $this->writeFixture();
+        $spy = $this->makeSpy();
+        $reader = StreamingXlsxReader::from($spy);
+
+        $count = iterator_count($reader->rows());
+        $this->assertSame(2001, $count); // header + 2000 rows
+
+        $this->assertNotEmpty($spy->streamCalls);
+        foreach ($spy->streamCalls as $c) {
+            $this->assertNull($c['length'], 'full scan must open streams unbounded');
+        }
+        $reader->close();
+    }
+}

--- a/tests/Readers/BoundedStreamTest.php
+++ b/tests/Readers/BoundedStreamTest.php
@@ -3,6 +3,7 @@
 namespace Kolay\XlsxStream\Tests\Readers;
 
 use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Contracts\SupportsBoundedStream;
 use Kolay\XlsxStream\Readers\StreamingXlsxReader;
 use Kolay\XlsxStream\Sinks\FileSink;
 use Kolay\XlsxStream\Sources\LocalFileSource;
@@ -56,10 +57,10 @@ class BoundedStreamTest extends TestCase
         $writer->finishFile();
     }
 
-    /** Spy Source recording every (offset, length) passed to streamFrom. */
+    /** Spy Source recording each open: unbounded streamFrom (length null) vs bounded streamFromRange. */
     private function makeSpy(): object
     {
-        return new class (new LocalFileSource($this->testFile)) implements Source {
+        return new class (new LocalFileSource($this->testFile)) implements Source, SupportsBoundedStream {
             /** @var list<array{offset: int, length: int|null}> */
             public array $streamCalls = [];
 
@@ -75,11 +76,18 @@ class BoundedStreamTest extends TestCase
                 return $this->inner->range($offset, $length);
             }
 
-            public function streamFrom(int $offset, ?int $length = null)
+            public function streamFrom(int $offset)
+            {
+                $this->streamCalls[] = ['offset' => $offset, 'length' => null];
+
+                return $this->inner->streamFrom($offset);
+            }
+
+            public function streamFromRange(int $offset, int $length)
             {
                 $this->streamCalls[] = ['offset' => $offset, 'length' => $length];
 
-                return $this->inner->streamFrom($offset, $length);
+                return $this->inner->streamFromRange($offset, $length);
             }
 
             public function close(): void

--- a/tests/Readers/BucketTest.php
+++ b/tests/Readers/BucketTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\Bucket;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * E4 — Bucket::year/month/day: ready-made monotone bucket callables for
+ * groupStats() over a date column, so "GROUP BY month" is one call
+ * instead of hand-rolling the Excel-serial → calendar math. The buckets
+ * mirror the reader's serial convention (unix = (serial − 25569) × 86400)
+ * and stay monotone, so the group-pure block pushdown still applies.
+ */
+class BucketTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-bucket-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /** One row per day across ~5 months in 2026; amount = day-of-run. */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 30)->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(30);
+        $writer->startFile(['day', 'amount']);
+        $base = new \DateTimeImmutable('2026-01-01 00:00:00', new \DateTimeZone('UTC'));
+        for ($i = 0; $i < 150; $i++) {
+            $writer->writeRow([$base->modify("+{$i} days"), (float) ($i + 1)]);
+        }
+        $writer->finishFile();
+    }
+
+    public function test_bucket_helpers_produce_expected_keys(): void
+    {
+        // Excel serial for 2026-03-15 UTC: (unix + 2209161600)/86400.
+        $unix = (new \DateTimeImmutable('2026-03-15 00:00:00', new \DateTimeZone('UTC')))->getTimestamp();
+        $serial = ($unix + 2209161600) / 86400;
+
+        $this->assertSame(2026, (Bucket::year())($serial));
+        $this->assertSame(202603, (Bucket::month())($serial));
+        $this->assertSame(20260315, (Bucket::day())($serial));
+    }
+
+    public function test_group_by_month_matches_manual_oracle(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $stats = $reader->groupStats(1, 2, Bucket::month());
+
+        // Oracle: bucket every row's date the same way.
+        $base = new \DateTimeImmutable('2026-01-01 00:00:00', new \DateTimeZone('UTC'));
+        $oracle = [];
+        for ($i = 0; $i < 150; $i++) {
+            $ym = (int) $base->modify("+{$i} days")->format('Ym');
+            $oracle[$ym] = ($oracle[$ym] ?? 0.0) + ($i + 1);
+        }
+
+        $got = [];
+        foreach ($stats as $row) {
+            $got[(int) $row['group']] = $row['sum'];
+        }
+        ksort($got);
+
+        $this->assertSame(array_keys($oracle), array_keys($got), 'month buckets mismatch');
+        foreach ($oracle as $ym => $sum) {
+            $this->assertEqualsWithDelta($sum, $got[$ym], 1e-6, "sum for {$ym}");
+        }
+        $reader->close();
+    }
+
+    public function test_group_by_year_collapses_to_one_group(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $stats = $reader->groupStats(1, 2, Bucket::year());
+        $this->assertCount(1, $stats);              // all 150 days are in 2026
+        $this->assertSame(2026, (int) $stats[0]['group']);
+        $this->assertSame(150, $stats[0]['count']);
+        $this->assertEqualsWithDelta(150 * 151 / 2, $stats[0]['sum'], 1e-6);
+        $reader->close();
+    }
+}

--- a/tests/Readers/GapBridgeTest.php
+++ b/tests/Readers/GapBridgeTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Contracts\ProvidesCostHints;
+use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Sources\LocalFileSource;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * G5 — gap-bridging: when a pruned scan leaves two surviving block runs
+ * separated by a short gap, a high-latency Source (via ProvidesCostHints)
+ * bridges the gap into ONE ranged read when the gap's compressed bytes
+ * transfer faster than a fresh round-trip. Zero-latency Sources (local,
+ * no hints) never bridge — run merging stays byte-for-byte the
+ * contiguous-only behaviour. Bridging is a fetch-count optimization only;
+ * results must always equal the full-scan oracle.
+ */
+class GapBridgeTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-bridge-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /**
+     * col2 = 500 only for the first 100 and last 100 ids, else 1 — so a
+     * `col2 = 500` query survives the first and last blocks with a big
+     * pruned gap between them (two runs).
+     */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'flag']);
+        for ($i = 1; $i <= 2000; $i++) {
+            $flag = ($i <= 100 || $i > 1900) ? 500 : 1;
+            $writer->writeRow([$i, $flag]);
+        }
+        $writer->finishFile();
+    }
+
+    /** Spy wrapping a source, counting streamFrom calls. Optionally advertises cost hints. */
+    private function makeSource(bool $withHints): object
+    {
+        $inner = new LocalFileSource($this->testFile);
+
+        if ($withHints) {
+            return new class ($inner) implements ProvidesCostHints, Source {
+                public int $streamCalls = 0;
+
+                public function __construct(private LocalFileSource $inner) {}
+
+                public function costHints(): array
+                {
+                    // Absurdly generous: a huge byte budget fits any gap,
+                    // so every gap should bridge.
+                    return ['rtt_us' => 1_000_000, 'bandwidth_bps' => 10_000_000_000];
+                }
+
+                public function size(): int
+                {
+                    return $this->inner->size();
+                }
+
+                public function range(int $offset, int $length): string
+                {
+                    return $this->inner->range($offset, $length);
+                }
+
+                public function streamFrom(int $offset, ?int $length = null)
+                {
+                    $this->streamCalls++;
+
+                    return $this->inner->streamFrom($offset, $length);
+                }
+
+                public function close(): void
+                {
+                    $this->inner->close();
+                }
+            };
+        }
+
+        return new class ($inner) implements Source {
+            public int $streamCalls = 0;
+
+            public function __construct(private LocalFileSource $inner) {}
+
+            public function size(): int
+            {
+                return $this->inner->size();
+            }
+
+            public function range(int $offset, int $length): string
+            {
+                return $this->inner->range($offset, $length);
+            }
+
+            public function streamFrom(int $offset, ?int $length = null)
+            {
+                $this->streamCalls++;
+
+                return $this->inner->streamFrom($offset, $length);
+            }
+
+            public function close(): void
+            {
+                $this->inner->close();
+            }
+        };
+    }
+
+    private function expectedRows(): array
+    {
+        // ids 1..100 and 1901..2000 carry flag 500.
+        return array_merge(range(1, 100), range(1901, 2000));
+    }
+
+    public function test_no_hints_source_does_not_bridge(): void
+    {
+        $this->writeFixture();
+        $spy = $this->makeSource(withHints: false);
+        $reader = StreamingXlsxReader::from($spy);
+
+        $spy->streamCalls = 0;
+        $hits = iterator_to_array($reader->rowsWhere(2, '=', 500));
+
+        $this->assertSame($this->expectedRows(), array_map(fn ($r) => (int) $r[0], array_values($hits)));
+        // First-block run and last-block run are separate fetches.
+        $this->assertGreaterThanOrEqual(2, $spy->streamCalls, 'zero-latency source must not bridge the gap');
+        $reader->close();
+    }
+
+    public function test_high_latency_source_bridges_gap_into_one_fetch(): void
+    {
+        $this->writeFixture();
+        $spy = $this->makeSource(withHints: true);
+        $reader = StreamingXlsxReader::from($spy);
+
+        $spy->streamCalls = 0;
+        $hits = iterator_to_array($reader->rowsWhere(2, '=', 500));
+
+        // Same rows — bridging is a fetch optimization, never a result change.
+        $this->assertSame($this->expectedRows(), array_map(fn ($r) => (int) $r[0], array_values($hits)));
+        // The two runs collapse into a single ranged read.
+        $this->assertSame(1, $spy->streamCalls, 'high-latency source must bridge the gap into one fetch');
+        $reader->close();
+    }
+}

--- a/tests/Readers/GroupStatsTest.php
+++ b/tests/Readers/GroupStatsTest.php
@@ -411,11 +411,11 @@ class GroupStatsTest extends TestCase
                 return $this->inner->range($offset, $length);
             }
 
-            public function streamFrom(int $offset)
+            public function streamFrom(int $offset, ?int $length = null)
             {
                 $this->streamOffsets[] = $offset;
 
-                return $this->inner->streamFrom($offset);
+                return $this->inner->streamFrom($offset, $length);
             }
 
             public function close(): void

--- a/tests/Readers/NamedColumnsTest.php
+++ b/tests/Readers/NamedColumnsTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Exceptions\XlsxReadException;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * v3.3 E1 — named column addressing on the reader's query surface.
+ *
+ * Written RED-FIRST against the int-only API. The contract under test:
+ *
+ *   - Every query API (columnStats, quantile/median, countDistinct,
+ *     rowsWhere, findRow, groupStats) and castColumn/castColumns accept
+ *     a header NAME wherever they accepted a column number, and the
+ *     named call returns EXACTLY what the equivalent numeric call
+ *     returns — names are sugar, never a second code path.
+ *   - A string is ALWAYS a name — '2024' looks up a header called
+ *     "2024", it is never coerced to column 2024 (ambiguity ban).
+ *   - Duplicate header names throw (naming both positions); unknown
+ *     names throw listing the available headers (pit-of-success).
+ *   - The 1-based (query APIs) vs 0-based (castColumn) split becomes
+ *     invisible when addressing by name — the exact trap E1 removes.
+ */
+class NamedColumnsTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->file = sys_get_temp_dir().'/kxs-named-'.uniqid('', true).'.xlsx';
+
+        $writer = new SinkableXlsxWriter(new FileSink($this->file));
+        $writer->withRandomAccessIndex(every: 500);
+        $writer->withColumnStats([1, 2]);
+        $writer->withColumnSketches([1, 2]);
+        $writer->startFile(['ID', 'Amount', 'City', '2024', '', 'Tarih']);
+
+        for ($i = 1; $i <= 2000; $i++) {
+            $writer->writeRow([$i, $i * 2.5, 'c'.($i % 7), $i % 100, 'x'.$i, 45000 + $i]);
+        }
+        $writer->finishFile();
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->file);
+        parent::tearDown();
+    }
+
+    private function reader(): StreamingXlsxReader
+    {
+        return StreamingXlsxReader::fromFile($this->file);
+    }
+
+    public function test_query_apis_accept_names_and_match_numeric_calls(): void
+    {
+        $byInt = $this->reader();
+        $byName = $this->reader();
+
+        $this->assertSame($byInt->columnStats(2), $byName->columnStats('Amount'));
+        $this->assertSame($byInt->quantile(2, 0.9), $byName->quantile('Amount', 0.9));
+        $this->assertSame($byInt->median(1), $byName->median('ID'));
+        $this->assertSame($byInt->countDistinct(3), $byName->countDistinct('City'));
+        $this->assertSame($byInt->findRow(1, 1500), $byName->findRow('ID', 1500));
+
+        $intRows = iterator_to_array($byInt->rowsWhere(2, 'between', 100.0, 110.0));
+        $nameRows = iterator_to_array($byName->rowsWhere('Amount', 'between', 100.0, 110.0));
+        $this->assertNotEmpty($intRows);
+        $this->assertSame($intRows, $nameRows);
+
+        $bucket = fn (float $v) => intdiv((int) $v, 500);
+        $this->assertSame(
+            $byInt->groupStats(1, 2, $bucket),
+            $byName->groupStats('ID', 'Amount', $bucket)
+        );
+    }
+
+    public function test_cast_column_by_name_matches_zero_based_numeric(): void
+    {
+        $byInt = $this->reader()->castColumn(1, 'float');   // 0-based -> Amount
+        $byName = $this->reader()->castColumn('Amount', 'float');
+
+        $a = iterator_to_array($byInt->rows(skip: 1, limit: 3), false);
+        $b = iterator_to_array($byName->rows(skip: 1, limit: 3), false);
+
+        $this->assertSame($a, $b);
+        $this->assertSame(2.5, $a[0][1]);
+    }
+
+    public function test_cast_columns_accepts_name_keys(): void
+    {
+        $reader = $this->reader()->castColumns(['Amount' => 'float', 'ID' => 'int']);
+
+        $row = iterator_to_array($reader->rows(skip: 1, limit: 1), false)[0];
+        $this->assertSame(1, $row[0]);
+        $this->assertSame(2.5, $row[1]);
+    }
+
+    public function test_numeric_looking_string_is_a_name_not_an_index(): void
+    {
+        // '2024' is the 4th header — NOT column 2024.
+        $stats = $this->reader()->rowsWhere('2024', '=', 42.0);
+        $first = null;
+        foreach ($stats as $rn => $row) {
+            $first = [$rn, $row];
+            break;
+        }
+
+        $this->assertNotNull($first);
+        $this->assertSame('42', (string) $first[1][3]);
+    }
+
+    public function test_unknown_name_throws_listing_headers(): void
+    {
+        try {
+            $this->reader()->columnStats('Amonut');
+            $this->fail('expected unknown-column exception');
+        } catch (XlsxReadException $e) {
+            $this->assertStringContainsString('Amonut', $e->getMessage());
+            $this->assertStringContainsString('Amount', $e->getMessage()); // available list
+            $this->assertStringContainsString('City', $e->getMessage());
+        }
+    }
+
+    public function test_duplicate_header_name_throws_with_both_positions(): void
+    {
+        $dup = sys_get_temp_dir().'/kxs-named-dup-'.uniqid('', true).'.xlsx';
+        $writer = new SinkableXlsxWriter(new FileSink($dup));
+        $writer->startFile(['ID', 'Amount', 'Amount']);
+        $writer->writeRow([1, 10, 20]);
+        $writer->finishFile();
+
+        try {
+            $reader = StreamingXlsxReader::fromFile($dup);
+            try {
+                $reader->countDistinct('Amount');
+                $this->fail('expected ambiguous-column exception');
+            } catch (XlsxReadException $e) {
+                $this->assertStringContainsString('Amount', $e->getMessage());
+                $this->assertStringContainsString('2', $e->getMessage());
+                $this->assertStringContainsString('3', $e->getMessage());
+            }
+            // Unambiguous names on the same sheet keep working.
+            $this->assertNull($reader->columnStats('ID'));
+        } finally {
+            @unlink($dup);
+        }
+    }
+
+    public function test_empty_header_cell_is_not_addressable(): void
+    {
+        // Column 5's header is '' — no name can reach it, but the
+        // sheet's other names still resolve (the empty cell is skipped,
+        // not an error).
+        $this->assertNotNull($this->reader()->columnStats('Amount'));
+
+        $this->expectException(XlsxReadException::class);
+        $this->reader()->columnStats('');
+    }
+
+    public function test_named_cast_and_auto_detect_dates_interact_like_numeric(): void
+    {
+        // castColumn by name must land in the same skip-set slot the
+        // numeric form uses, so autoDetectDates() exempts the column
+        // identically on both paths.
+        $byInt = $this->reader()->autoDetectDates()->castColumn(5, fn ($v) => 'RAW:'.$v);
+        $byName = $this->reader()->autoDetectDates()->castColumn('Tarih', fn ($v) => 'RAW:'.$v);
+
+        $a = iterator_to_array($byInt->rows(skip: 1, limit: 2), false);
+        $b = iterator_to_array($byName->rows(skip: 1, limit: 2), false);
+
+        $this->assertSame($a, $b);
+        $this->assertSame('RAW:45001', $a[0][5]);
+    }
+
+    public function test_names_follow_the_active_sheet(): void
+    {
+        $multi = sys_get_temp_dir().'/kxs-named-multi-'.uniqid('', true).'.xlsx';
+        $writer = new SinkableXlsxWriter(new FileSink($multi));
+        $writer->withRandomAccessIndex();
+        $writer->withColumnStats([1]);
+        $writer->startFile(['ID', 'Amount']);
+        for ($i = 1; $i <= 10; $i++) {
+            $writer->writeRow([$i, $i * 2]);
+        }
+        $writer->newSheet('Totals', ['Region', 'Sum']);
+        for ($i = 1; $i <= 5; $i++) {
+            $writer->writeRow([$i * 100, $i]);
+        }
+        $writer->finishFile();
+
+        try {
+            $reader = StreamingXlsxReader::fromFile($multi);
+            $this->assertSame(10.0, $reader->columnStats('ID')['max']);
+
+            $reader->onSheet('Totals');
+            $this->assertSame(500.0, $reader->columnStats('Region')['max']);
+
+            // Sheet 1's names no longer resolve on Totals.
+            $this->expectException(XlsxReadException::class);
+            $reader->columnStats('Amount');
+        } finally {
+            @unlink($multi);
+        }
+    }
+}

--- a/tests/Readers/OnFullScanTest.php
+++ b/tests/Readers/OnFullScanTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * E2 — onFullScan(): an observability hook fired when a query CANNOT use
+ * the index and degrades to a full row scan (an unindexed column, an
+ * un-sorted groupBy). It lets callers log/alert when a query isn't
+ * getting the pushdown they expect — the difference between a
+ * millisecond sidecar answer and reading the whole sheet.
+ */
+class OnFullScanTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-fullscan-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /** col1 indexed (stats), col2 NOT indexed. */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100)->withColumnStats([1]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['indexed', 'plain']);
+        for ($i = 1; $i <= 500; $i++) {
+            $writer->writeRow([$i, $i * 3]);
+        }
+        $writer->finishFile();
+    }
+
+    public function test_hook_fires_when_querying_an_unindexed_column(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $events = [];
+        $reader->onFullScan(function (array $ctx) use (&$events) {
+            $events[] = $ctx;
+        });
+
+        iterator_to_array($reader->rowsWhere(2, '>=', 100)); // col2 has no zone maps
+
+        $this->assertNotEmpty($events, 'querying an unindexed column must fire onFullScan');
+        $this->assertSame('rowsWhere', $events[0]['query']);
+        $this->assertSame(2, $events[0]['column']);
+        $reader->close();
+    }
+
+    public function test_hook_does_not_fire_when_pushdown_applies(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $fired = false;
+        $reader->onFullScan(function () use (&$fired) {
+            $fired = true;
+        });
+
+        iterator_to_array($reader->rowsWhere(1, '>=', 400)); // col1 IS indexed
+        $this->assertFalse($fired, 'an indexed query must not fire onFullScan');
+        $reader->close();
+    }
+
+    public function test_hook_fires_for_group_stats_without_pushdown_basis(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $events = [];
+        $reader->onFullScan(function (array $ctx) use (&$events) {
+            $events[] = $ctx;
+        });
+
+        // groupBy col2 has no stats -> no pushdown -> full scan.
+        $reader->groupStats(2, 1);
+        $this->assertNotEmpty($events);
+        $this->assertSame('groupStats', $events[0]['query']);
+        $reader->close();
+    }
+
+    public function test_hook_fires_for_rows_where_all_without_indexed_predicate(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $events = [];
+        $reader->onFullScan(function (array $ctx) use (&$events) {
+            $events[] = $ctx;
+        });
+
+        // Neither predicate touches an indexed column.
+        iterator_to_array($reader->rowsWhereAll([[2, '>=', 100], [2, '<=', 400]]));
+        $this->assertNotEmpty($events);
+        $this->assertSame('rowsWhereAll', $events[0]['query']);
+        $reader->close();
+    }
+}

--- a/tests/Readers/QueryPushdownTest.php
+++ b/tests/Readers/QueryPushdownTest.php
@@ -170,11 +170,11 @@ class QueryPushdownTest extends TestCase
                 return $this->inner->range($offset, $length);
             }
 
-            public function streamFrom(int $offset)
+            public function streamFrom(int $offset, ?int $length = null)
             {
                 $this->streamOffsets[] = $offset;
 
-                return $this->inner->streamFrom($offset);
+                return $this->inner->streamFrom($offset, $length);
             }
 
             public function close(): void

--- a/tests/Readers/RowEstimateTest.php
+++ b/tests/Readers/RowEstimateTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * G2 — estimatedRows() and explain(): zero-I/O selectivity estimation
+ * and query planning from data already in the sidecar (no row read).
+ *
+ * The load-bearing invariant is the UPPER BOUND: estimatedRows()['upper']
+ * (the summed row-count of zone-map surviving blocks) must NEVER be below
+ * the true match count — it is a bound, not a guess. The digest estimate
+ * is approximate and only checked for a sane order of magnitude.
+ */
+class RowEstimateTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-estimate-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /** 5000 rows, sync every 100. col1 = id asc, col2 = amount asc-ish. */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 2]);
+        $writer->withColumnSketches([1, 2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'amount']);
+        for ($i = 1; $i <= 5000; $i++) {
+            $writer->writeRow([$i, round($i * 2.0, 2)]);
+        }
+        $writer->finishFile();
+    }
+
+    private function actualCount(StreamingXlsxReader $reader, int $col, string $op, float $v, ?float $v2 = null): int
+    {
+        $n = 0;
+        $idx = $col - 1;
+        foreach ($reader->rows() as $row) {
+            $x = is_numeric($row[$idx] ?? null) ? (float) $row[$idx] : null;
+            if ($x === null) {
+                continue;
+            }
+            $hit = match ($op) {
+                '>=' => $x >= $v,
+                '<=' => $x <= $v,
+                'between' => $x >= $v && $x <= $v2,
+                '=' => $x == $v,
+                default => false,
+            };
+            if ($hit) {
+                $n++;
+            }
+        }
+
+        return $n;
+    }
+
+    public function test_upper_bound_never_below_actual(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $cases = [
+            [1, 'between', 2000.0, 2500.0],
+            [1, '>=', 4000.0, null],
+            [2, 'between', 1000.0, 3000.0],
+            [2, '<=', 500.0, null],
+        ];
+        foreach ($cases as [$col, $op, $v, $v2]) {
+            $est = $reader->estimatedRows($col, $op, $v, $v2);
+            $this->assertNotNull($est);
+            $actual = $this->actualCount($reader, $col, $op, $v, $v2);
+            $this->assertGreaterThanOrEqual(
+                $actual,
+                $est['upper'],
+                "upper bound violated for col{$col} {$op} {$v}"
+            );
+        }
+        $reader->close();
+    }
+
+    public function test_digest_estimate_lands_near_actual(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        // Uniform 1..5000 -> a mid-range band's estimate should be within
+        // a few % (t-digest rank error is worst mid-range but small).
+        $est = $reader->estimatedRows(1, 'between', 2000, 2500);
+        $this->assertNotNull($est['estimate']);
+        $actual = $this->actualCount($reader, 1, 'between', 2000.0, 2500.0); // 501
+        $this->assertEqualsWithDelta($actual, $est['estimate'], $actual * 0.15);
+        $reader->close();
+    }
+
+    public function test_estimated_rows_null_without_zone_maps(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['id']);
+        for ($i = 1; $i <= 100; $i++) {
+            $writer->writeRow([$i]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $this->assertNull($reader->estimatedRows(1, '>=', 50));
+        $reader->close();
+    }
+
+    public function test_explain_shapes_the_plan_without_reading_rows(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $plan = $reader->explain([[1, 'between', 2000, 2500], [2, '>=', 100]]);
+
+        $this->assertSame('zone-map-prune', $plan['strategy']);
+        $this->assertArrayHasKey('candidateBlocks', $plan);
+        $this->assertArrayHasKey('runs', $plan);
+        $this->assertGreaterThanOrEqual(1, $plan['runs']);
+        $this->assertArrayHasKey('estimatedRows', $plan);
+        $this->assertArrayHasKey('upper', $plan['estimatedRows']);
+        $this->assertArrayHasKey('estimate', $plan['estimatedRows']);
+        $this->assertArrayHasKey('estimatedBytes', $plan);
+
+        // The plan's upper bound must cover the real AND result.
+        $actual = count(iterator_to_array($reader->rowsWhereAll([[1, 'between', 2000, 2500], [2, '>=', 100]]), false));
+        $this->assertGreaterThanOrEqual($actual, $plan['estimatedRows']['upper']);
+
+        // estimatedBytes is a real byte budget: > 0 and no larger than the
+        // whole sheet's compressed size.
+        $this->assertGreaterThan(0, $plan['estimatedBytes']);
+
+        // candidateBlocks is a real, pruned count: at least one block for
+        // a matching band, well under the ~50 blocks of a 5000-row/every-100
+        // sheet (pruning actually happened).
+        $this->assertGreaterThanOrEqual(1, $plan['candidateBlocks']);
+        $this->assertLessThanOrEqual(60, $plan['candidateBlocks']);
+        $reader->close();
+    }
+
+    public function test_explain_reports_full_scan_without_stats(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['id']);
+        for ($i = 1; $i <= 100; $i++) {
+            $writer->writeRow([$i]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $plan = $reader->explain([[1, '>=', 50]]);
+        $this->assertSame('full-scan', $plan['strategy']);
+        $reader->close();
+    }
+}

--- a/tests/Readers/RowSampleTest.php
+++ b/tests/Readers/RowSampleTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * D3 — sampleRows(): a uniform random sample of k rows fetched via the
+ * index (≈k block reads, not a full N-row scan). k distinct row numbers
+ * are drawn uniformly from the data range with a seeded Mt19937
+ * Randomizer, then those exact rows are read. Unbiasedness is proven in
+ * poc/d3_sample.php (chi-square); these tests pin the surface: a fixed
+ * seed reproduces the sample, the sampled rows are REAL rows read
+ * correctly, the count is exact, and edge sizes behave.
+ */
+class RowSampleTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-sample-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    private function writeFixture(bool $indexed = true): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        if ($indexed) {
+            $writer->withRandomAccessIndex(every: 100);
+        }
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'label']);
+        for ($i = 1; $i <= 1000; $i++) {
+            $writer->writeRow([$i, 'label-'.$i]);
+        }
+        $writer->finishFile();
+    }
+
+    public function test_same_seed_reproduces_the_sample(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $a = $reader->sampleRows(30, seed: 42);
+        $b = $reader->sampleRows(30, seed: 42);
+        $this->assertSame($a, $b, 'a fixed seed must reproduce the exact sample');
+        $reader->close();
+    }
+
+    public function test_different_seeds_differ(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $a = array_keys($reader->sampleRows(30, seed: 1));
+        $b = array_keys($reader->sampleRows(30, seed: 2));
+        $this->assertNotSame($a, $b, 'different seeds should draw different rows');
+        $reader->close();
+    }
+
+    public function test_sampled_rows_are_real_rows_read_correctly(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $sample = $reader->sampleRows(40, seed: 7);
+        $this->assertCount(40, $sample);
+
+        foreach ($sample as $rn => $row) {
+            // Data row rn holds id = rn - 1 (row 2 => id 1) and its label.
+            $this->assertSame((string) ($rn - 1), $row[0], "row {$rn} id mismatch");
+            $this->assertSame('label-'.($rn - 1), $row[1], "row {$rn} label mismatch");
+        }
+
+        // Keys are ascending, distinct, and within the data range.
+        $keys = array_keys($sample);
+        $sorted = $keys;
+        sort($sorted);
+        $this->assertSame($sorted, $keys, 'sample must be in ascending row order');
+        $this->assertSame($keys, array_values(array_unique($keys)), 'no duplicate rows');
+        $this->assertGreaterThanOrEqual(2, min($keys));
+        $this->assertLessThanOrEqual(1001, max($keys));
+        $reader->close();
+    }
+
+    public function test_k_at_or_above_row_count_returns_all(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $all = $reader->sampleRows(999999, seed: 1);
+        $this->assertCount(1000, $all);
+        $this->assertSame(range(2, 1001), array_keys($all));
+        $reader->close();
+    }
+
+    public function test_k_zero_or_negative_returns_empty(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $this->assertSame([], $reader->sampleRows(0));
+        $this->assertSame([], $reader->sampleRows(-5));
+        $reader->close();
+    }
+
+    public function test_sample_spreads_across_the_file(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        // A uniform sample of 100 from 1000 should touch both halves, not
+        // cluster at one end (a coarse unbiasedness canary; the rigorous
+        // chi-square lives in poc/d3_sample.php).
+        $keys = array_keys($reader->sampleRows(100, seed: 123));
+        $firstHalf = array_filter($keys, fn ($rn) => $rn <= 501);
+        $secondHalf = array_filter($keys, fn ($rn) => $rn > 501);
+        $this->assertGreaterThan(20, count($firstHalf));
+        $this->assertGreaterThan(20, count($secondHalf));
+        $reader->close();
+    }
+
+    public function test_works_without_an_index(): void
+    {
+        $this->writeFixture(indexed: false);
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $sample = $reader->sampleRows(15, seed: 5);
+        $this->assertCount(15, $sample);
+        foreach ($sample as $rn => $row) {
+            $this->assertSame((string) ($rn - 1), $row[0]);
+        }
+        $reader->close();
+    }
+}

--- a/tests/Readers/RowsSkipFastPathTest.php
+++ b/tests/Readers/RowsSkipFastPathTest.php
@@ -166,11 +166,11 @@ class RowsSkipFastPathTest extends TestCase
                 return $this->inner->range($offset, $length);
             }
 
-            public function streamFrom(int $offset)
+            public function streamFrom(int $offset, ?int $length = null)
             {
                 $this->streamOffsets[] = $offset;
 
-                return $this->inner->streamFrom($offset);
+                return $this->inner->streamFrom($offset, $length);
             }
 
             public function close(): void

--- a/tests/Readers/RowsWhereAllTest.php
+++ b/tests/Readers/RowsWhereAllTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * G1 — rowsWhereAll(): multi-predicate AND with zone-map INTERSECTION.
+ *
+ * The surviving-block set of each predicate is intersected: a row that
+ * satisfies every predicate must live in a block that survives every
+ * predicate (zone maps are sound — they widen, never narrow), so the
+ * intersection can only shrink the candidate set, never drop a match.
+ * The pruned AND-scan must return exactly the full-scan oracle's rows.
+ *
+ * Correctness oracle is always the brute force: full scan + per-row
+ * filter by all predicates.
+ */
+class RowsWhereAllTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-whereall-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /**
+     * 2000 rows, sync every 100. col1 = id ascending (clusters tightly),
+     * col2 = (id*7 % 2000) a permutation (scatters across blocks), col3
+     * = untracked text.
+     */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'perm', 'name']);
+        for ($i = 1; $i <= 2000; $i++) {
+            $writer->writeRow([$i, ($i * 7) % 2000, 'name-'.$i]);
+        }
+        $writer->finishFile();
+    }
+
+    /** @param list<array{0:int|string,1:string,2:int|float,3?:int|float}> $predicates */
+    private function oracle(StreamingXlsxReader $reader, array $predicates): array
+    {
+        $rows = [];
+        foreach ($reader->rows() as $row) {
+            $ok = true;
+            foreach ($predicates as $p) {
+                $col0 = ((int) $p[0]) - 1;
+                $v = is_numeric($row[$col0] ?? null) ? (float) $row[$col0] : null;
+                $match = match ($p[1]) {
+                    '=' => $v !== null && $v == $p[2],
+                    '>=' => $v !== null && $v >= $p[2],
+                    '<=' => $v !== null && $v <= $p[2],
+                    '>' => $v !== null && $v > $p[2],
+                    '<' => $v !== null && $v < $p[2],
+                    'between' => $v !== null && $v >= $p[2] && $v <= $p[3],
+                    default => false,
+                };
+                if (! $match) {
+                    $ok = false;
+                    break;
+                }
+            }
+            if ($ok) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
+    }
+
+    public function test_and_scan_matches_full_scan_oracle(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $predicates = [[1, 'between', 400, 600], [2, 'between', 800, 1200]];
+        $oracle = $this->oracle($reader, $predicates);
+        $got = iterator_to_array($reader->rowsWhereAll($predicates), false);
+
+        $this->assertSame($oracle, $got);
+        $this->assertNotEmpty($got, 'fixture should produce some AND matches');
+        $reader->close();
+    }
+
+    public function test_result_is_subset_of_each_single_predicate(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $p1 = [1, 'between', 400, 600];
+        $p2 = [2, 'between', 800, 1200];
+
+        $single1 = iterator_to_array($reader->rowsWhere($p1[0], $p1[1], $p1[2], $p1[3]), false);
+        $single2 = iterator_to_array($reader->rowsWhere($p2[0], $p2[1], $p2[2], $p2[3]), false);
+        $both = iterator_to_array($reader->rowsWhereAll([$p1, $p2]), false);
+
+        // AND ⊆ each side.
+        $this->assertLessThanOrEqual(count($single1), count($both));
+        $this->assertLessThanOrEqual(count($single2), count($both));
+        foreach ($both as $row) {
+            $this->assertContains($row, $single1);
+            $this->assertContains($row, $single2);
+        }
+        $reader->close();
+    }
+
+    public function test_predicate_without_stats_still_filters_per_row(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        // col3 (name) carries no zone maps — it cannot prune blocks but
+        // its predicate must still filter rows. Combine with a statful
+        // col1 band so blocks are pruned by col1 and rows by col3.
+        // name column is text → numeric predicates never match it, so
+        // the whole AND is empty. Pair a matchable col1 with an
+        // unmatchable col3 predicate.
+        $got = iterator_to_array($reader->rowsWhereAll([[1, 'between', 400, 600], [3, '>=', 0]]), false);
+        $this->assertSame([], $got, 'text column never satisfies a numeric predicate');
+        $reader->close();
+    }
+
+    public function test_predicates_address_columns_by_name(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $byIndex = iterator_to_array($reader->rowsWhereAll([[1, 'between', 400, 600], [2, 'between', 800, 1200]]), false);
+        $byName = iterator_to_array($reader->rowsWhereAll([['id', 'between', 400, 600], ['perm', 'between', 800, 1200]]), false);
+
+        $this->assertSame($byIndex, $byName);
+        $reader->close();
+    }
+
+    public function test_no_stats_file_falls_back_to_full_scan(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['id', 'perm']);
+        for ($i = 1; $i <= 200; $i++) {
+            $writer->writeRow([$i, ($i * 7) % 200]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $predicates = [[1, '>=', 100], [2, '<=', 50]];
+        $oracle = $this->oracle($reader, $predicates);
+        $got = iterator_to_array($reader->rowsWhereAll($predicates), false);
+
+        $this->assertSame($oracle, $got);
+        $reader->close();
+    }
+
+    public function test_empty_predicates_throws(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $this->expectException(\InvalidArgumentException::class);
+        iterator_to_array($reader->rowsWhereAll([]));
+    }
+}

--- a/tests/Readers/SketchQueryTest.php
+++ b/tests/Readers/SketchQueryTest.php
@@ -241,11 +241,11 @@ class SketchQueryTest extends TestCase
                 return $this->inner->range($offset, $length);
             }
 
-            public function streamFrom(int $offset)
+            public function streamFrom(int $offset, ?int $length = null)
             {
                 $this->streamCalls++;
 
-                return $this->inner->streamFrom($offset);
+                return $this->inner->streamFrom($offset, $length);
             }
 
             public function close(): void

--- a/tests/Readers/StreamingSheetReaderTest.php
+++ b/tests/Readers/StreamingSheetReaderTest.php
@@ -336,7 +336,7 @@ class StallingSource implements Source
         return $this->inner->range($offset, $length);
     }
 
-    public function streamFrom(int $offset)
+    public function streamFrom(int $offset, ?int $length = null)
     {
         // Buffer remaining bytes so the stalling wrapper can replay them
         // after the empty-read streak. Fine for test fixtures.

--- a/tests/Readers/TopRowsTest.php
+++ b/tests/Readers/TopRowsTest.php
@@ -175,6 +175,95 @@ class TopRowsTest extends TestCase
         $reader->close();
     }
 
+    /**
+     * A sorted column may carry non-numeric cells (optional amount/discount
+     * columns) — the sorted flag orders only numeric cells. The extremes
+     * must be the true numeric extremes, never the null/text cells that
+     * happen to sit at the sheet end. Regression: the fast path used to
+     * read the fixed k rows at the end and return them verbatim, so a
+     * null-tailed asc column returned empties instead of the real maxima.
+     */
+    private function writeNullEndFixture(bool $nullsAtTail): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'score']);
+        // Asc-sorted numeric core; a run of null-score rows at one end.
+        if ($nullsAtTail) {
+            for ($i = 1; $i <= 1000; $i++) {
+                $writer->writeRow([$i, $i * 1.5]);
+            }
+            for ($i = 1001; $i <= 1015; $i++) {
+                $writer->writeRow([$i, null]);
+            }
+        } else {
+            for ($i = 1; $i <= 15; $i++) {
+                $writer->writeRow([$i, null]);
+            }
+            for ($i = 16; $i <= 1015; $i++) {
+                $writer->writeRow([$i, ($i - 15) * 1.5]);
+            }
+        }
+        $writer->finishFile();
+    }
+
+    public function test_largest_ignores_null_tail_on_sorted_column(): void
+    {
+        $this->writeNullEndFixture(nullsAtTail: true);
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $top = $reader->topRows(2, 3, desc: true);
+        $this->assertSame(
+            [1500.0, 1498.5, 1497.0],
+            array_map(fn ($r) => (float) $r[1], array_values($top))
+        );
+        $this->assertSame($this->oracle($reader, 2, 3, true), array_map(fn ($r) => (float) $r[1], $top));
+        $reader->close();
+    }
+
+    public function test_smallest_ignores_null_head_on_sorted_column(): void
+    {
+        $this->writeNullEndFixture(nullsAtTail: false);
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $top = $reader->topRows(2, 3, desc: false);
+        $this->assertSame(
+            [1.5, 3.0, 4.5],
+            array_map(fn ($r) => (float) $r[1], array_values($top))
+        );
+        $this->assertSame($this->oracle($reader, 2, 3, false), array_map(fn ($r) => (float) $r[1], $top));
+        $reader->close();
+    }
+
+    public function test_null_scattered_including_extreme_window_matches_oracle(): void
+    {
+        // Nulls scattered through the column, some landing in the last k
+        // rows — the exact shape that slipped a null into the result.
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100)->withColumnStats([2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'score']);
+        for ($i = 1; $i <= 1000; $i++) {
+            $writer->writeRow([$i, $i % 25 === 0 ? null : $i * 1.5]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        foreach ([true, false] as $desc) {
+            $top = $reader->topRows(2, 8, desc: $desc);
+            $oracle = $this->oracle($reader, 2, 8, $desc);
+            $this->assertSame(array_keys($oracle), array_keys($top), 'desc='.var_export($desc, true));
+            $this->assertSame($oracle, array_map(fn ($r) => (float) $r[1], $top));
+            // No non-numeric cell may appear in the result.
+            foreach ($top as $row) {
+                $this->assertIsNumeric($row[1]);
+            }
+        }
+        $reader->close();
+    }
+
     public function test_addresses_column_by_name(): void
     {
         $this->writeFixture();

--- a/tests/Readers/TopRowsTest.php
+++ b/tests/Readers/TopRowsTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Sources\LocalFileSource;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * F1 — topRows(): "ORDER BY column [DESC] LIMIT k" over the sidecar.
+ *
+ * On a column the writer observed to be sorted, the k extremes sit at
+ * one end of the sheet, so topRows reads only the blocks at that end and
+ * early-exits — the spreadsheet form of an indexed ORDER BY … LIMIT. On
+ * an unsorted column it degrades to a single full scan holding an O(k)
+ * heap, still correct. The oracle is always the brute-force sort of a
+ * full scan.
+ */
+class TopRowsTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-toprows-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /** col1 = id ascending, col2 = a permutation (unsorted), col3 text. */
+    private function writeFixture(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'perm', 'name']);
+        for ($i = 1; $i <= 2000; $i++) {
+            $writer->writeRow([$i, ($i * 7) % 2000, 'name-'.$i]);
+        }
+        $writer->finishFile();
+    }
+
+    /** Brute-force ORDER BY col LIMIT k, returning [rn => row] in rank order. */
+    private function oracle(StreamingXlsxReader $reader, int $col, int $k, bool $desc): array
+    {
+        $idx = $col - 1;
+        $all = [];
+        foreach ($reader->rowRange(2, $reader->rowCount()) as $rn => $row) {
+            if (is_numeric($row[$idx] ?? null)) {
+                $all[$rn] = (float) $row[$idx];
+            }
+        }
+        uasort($all, fn ($a, $b) => $desc ? ($b <=> $a) : ($a <=> $b));
+
+        return array_slice($all, 0, $k, true);
+    }
+
+    private function makeSpy(): object
+    {
+        return new class (new LocalFileSource($this->testFile)) implements Source {
+            /** @var list<int> */
+            public array $offsets = [];
+
+            public function __construct(private LocalFileSource $inner) {}
+
+            public function size(): int
+            {
+                return $this->inner->size();
+            }
+
+            public function range(int $offset, int $length): string
+            {
+                return $this->inner->range($offset, $length);
+            }
+
+            public function streamFrom(int $offset, ?int $length = null)
+            {
+                $this->offsets[] = $offset;
+
+                return $this->inner->streamFrom($offset, $length);
+            }
+
+            public function close(): void
+            {
+                $this->inner->close();
+            }
+        };
+    }
+
+    public function test_top_largest_on_sorted_column(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $top = $reader->topRows(1, 5, desc: true);
+        $this->assertSame([2001, 2000, 1999, 1998, 1997], array_keys($top));
+        $this->assertSame([2000, 1999, 1998, 1997, 1996], array_map(fn ($r) => (int) $r[0], array_values($top)));
+
+        $this->assertSame($this->oracle($reader, 1, 5, true), array_map(fn ($r) => (float) $r[0], $top));
+        $reader->close();
+    }
+
+    public function test_top_smallest_on_sorted_column(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $top = $reader->topRows(1, 3, desc: false);
+        $this->assertSame([2, 3, 4], array_keys($top));
+        $this->assertSame([1, 2, 3], array_map(fn ($r) => (int) $r[0], array_values($top)));
+        $reader->close();
+    }
+
+    public function test_sorted_top_reads_only_the_end_blocks(): void
+    {
+        $this->writeFixture();
+        $spy = $this->makeSpy();
+        $reader = StreamingXlsxReader::from($spy);
+
+        // Warm the index + establish the full-scan start offset.
+        $reader->rowCount();
+        $spy->offsets = [];
+
+        $reader->topRows(1, 5, desc: true);
+
+        // The largest ids live in the LAST block — the read must seek well
+        // past the sheet start (not a full scan from offset ~0).
+        $this->assertNotEmpty($spy->offsets);
+        $this->assertGreaterThan(0, min($spy->offsets), 'sorted topRows must seek to the end, not scan from the start');
+        $reader->close();
+    }
+
+    public function test_top_on_unsorted_column_matches_oracle(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        foreach ([true, false] as $desc) {
+            $top = $reader->topRows(2, 7, desc: $desc);
+            $oracle = $this->oracle($reader, 2, 7, $desc);
+            $this->assertSame(array_keys($oracle), array_keys($top), 'row order mismatch (desc='.var_export($desc, true).')');
+            $this->assertSame(
+                array_values($oracle),
+                array_map(fn ($r) => (float) $r[1], array_values($top))
+            );
+        }
+        $reader->close();
+    }
+
+    public function test_k_larger_than_row_count_returns_all(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $top = $reader->topRows(1, 999999, desc: true);
+        $this->assertCount(2000, $top);
+        $reader->close();
+    }
+
+    public function test_k_zero_returns_empty(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $this->assertSame([], $reader->topRows(1, 0));
+        $reader->close();
+    }
+
+    public function test_addresses_column_by_name(): void
+    {
+        $this->writeFixture();
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        $this->assertSame(
+            $reader->topRows(2, 5, desc: true),
+            $reader->topRows('perm', 5, desc: true)
+        );
+        $reader->close();
+    }
+}

--- a/tests/Readers/VerifyTest.php
+++ b/tests/Readers/VerifyTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Readers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * Z3 — verify(): read-side integrity check against the writer's per-block
+ * (SCRC) and whole-sheet CRC pins. A clean file verifies ok; a byte
+ * flipped inside a sheet's compressed data (the ZIP central directory
+ * left intact, as a real storage bit-flip would leave it) is caught, and
+ * on a born-indexed file the damage is localized to a block.
+ */
+class VerifyTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-verify-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    private function writeFixture(bool $indexed = true): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        if ($indexed) {
+            $writer->withRandomAccessIndex(every: 100);
+        }
+        $writer->setBufferFlushInterval(100);
+        $writer->startFile(['id', 'name']);
+        for ($i = 1; $i <= 500; $i++) {
+            $writer->writeRow([$i, 'row-'.$i]);
+        }
+        $writer->finishFile();
+    }
+
+    /** Flip one byte inside sheet1.xml's COMPRESSED data, leaving the ZIP CD intact. */
+    private function corruptSheetData(): void
+    {
+        $data = file_get_contents($this->testFile);
+        $name = 'xl/worksheets/sheet1.xml';
+        $fnPos = strpos($data, $name);          // first hit = the local file header's name field
+        $this->assertNotFalse($fnPos);
+        $header = $fnPos - 30;                    // local header is 30 fixed bytes + name + extra
+        $this->assertSame("PK\x03\x04", substr($data, $header, 4), 'expected a local file header');
+        $compSize = unpack('V', substr($data, $header + 18, 4))[1];
+        $fnLen = unpack('v', substr($data, $header + 26, 2))[1];
+        $extraLen = unpack('v', substr($data, $header + 28, 2))[1];
+        $dataStart = $header + 30 + $fnLen + $extraLen;
+        $flipAt = $dataStart + intdiv($compSize, 2); // mid-stream -> corrupts a middle block
+        $data[$flipAt] = chr(ord($data[$flipAt]) ^ 0xFF);
+        file_put_contents($this->testFile, $data);
+    }
+
+    public function test_clean_indexed_file_verifies_ok(): void
+    {
+        $this->writeFixture(indexed: true);
+        $report = StreamingXlsxReader::fromFile($this->testFile)->verify();
+
+        $this->assertTrue($report['ok']);
+        $this->assertCount(1, $report['sheets']);
+        $sheet = $report['sheets'][0];
+        $this->assertTrue($sheet['ok']);
+        $this->assertTrue($sheet['sheet_crc_ok']);
+        $this->assertTrue($sheet['inflate_ok']);
+        $this->assertSame([], $sheet['corrupt_blocks']);
+        $this->assertGreaterThan(0, $sheet['blocks_checked']); // SCRC pins present
+    }
+
+    public function test_clean_unindexed_file_verifies_ok(): void
+    {
+        $this->writeFixture(indexed: false);
+        $report = StreamingXlsxReader::fromFile($this->testFile)->verify();
+
+        $this->assertTrue($report['ok']);
+        $this->assertSame(0, $report['sheets'][0]['blocks_checked']); // whole-entry CRC only
+        $this->assertTrue($report['sheets'][0]['sheet_crc_ok']);
+    }
+
+    public function test_corrupted_sheet_bytes_are_detected(): void
+    {
+        $this->writeFixture(indexed: true);
+        $this->corruptSheetData();
+
+        $report = StreamingXlsxReader::fromFile($this->testFile)->verify();
+
+        $this->assertFalse($report['ok'], 'a flipped byte in the sheet data must fail verification');
+        $sheet = $report['sheets'][0];
+        $this->assertFalse($sheet['ok']);
+        // Either a block CRC mismatched, the whole-sheet CRC mismatched, or
+        // the stream was too damaged to inflate — any of these means "bad".
+        $this->assertTrue(
+            $sheet['corrupt_blocks'] !== [] || ! $sheet['sheet_crc_ok'] || ! $sheet['inflate_ok'],
+            'corruption must surface as a bad block, a bad sheet CRC, or a failed inflate'
+        );
+    }
+
+    public function test_corruption_is_localized_to_a_block(): void
+    {
+        // With SCRC pins a mid-stream flip that still inflates should name a
+        // specific block rather than only failing the whole-sheet CRC.
+        $this->writeFixture(indexed: true);
+        $this->corruptSheetData();
+
+        $report = StreamingXlsxReader::fromFile($this->testFile)->verify();
+        $sheet = $report['sheets'][0];
+
+        // If it inflated, at least one SCRC checkpoint must have caught it.
+        if ($sheet['inflate_ok']) {
+            $this->assertNotEmpty($sheet['corrupt_blocks'], 'a block should be pinpointed when the stream still inflates');
+        } else {
+            $this->assertTrue(true); // too damaged to inflate — still correctly reported as bad
+        }
+    }
+}

--- a/tests/Readers/ZipDirectoryTest.php
+++ b/tests/Readers/ZipDirectoryTest.php
@@ -329,9 +329,9 @@ class RangeCountingSource implements \Kolay\XlsxStream\Contracts\Source
         return $this->inner->range($offset, $length);
     }
 
-    public function streamFrom(int $offset)
+    public function streamFrom(int $offset, ?int $length = null)
     {
-        return $this->inner->streamFrom($offset);
+        return $this->inner->streamFrom($offset, $length);
     }
 
     public function close(): void

--- a/tests/Sketches/TDigestTest.php
+++ b/tests/Sketches/TDigestTest.php
@@ -330,6 +330,98 @@ class TDigestTest extends TestCase
     }
 
     // ------------------------------------------------------------------
+    // rank() — the CDF (inverse of quantile)
+    // ------------------------------------------------------------------
+
+    public function test_rank_is_null_for_empty_digest(): void
+    {
+        $this->assertNull((new TDigest())->rank(1.0));
+    }
+
+    public function test_rank_boundary_conventions(): void
+    {
+        $d = new TDigest();
+        foreach (range(1.0, 100.0) as $v) {
+            $d->add($v);
+        }
+
+        $this->assertSame(0.0, $d->rank(1.0));      // at min
+        $this->assertSame(0.0, $d->rank(0.0));      // below min
+        $this->assertSame(1.0, $d->rank(100.0));    // at max
+        $this->assertSame(1.0, $d->rank(1000.0));   // above max
+    }
+
+    /**
+     * rank() and quantile() are numerical inverses within the digest's
+     * resolution: round-tripping through both lands back near the input
+     * rank. The round-trip error is bounded by the digest's own rank
+     * resolution (it cannot be tighter than the clustering allows).
+     */
+    public function test_rank_inverse_of_quantile_on_uniform(): void
+    {
+        mt_srand(42);
+        [$digest] = $this->build(fn () => mt_rand() / mt_getrandmax() * 1000.0);
+
+        // quantile→rank: feeding q's output back through rank recovers q
+        // within ~0.5% (the digest's mid-range resolution at δ=100).
+        foreach ([0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99] as $q) {
+            $v = $digest->quantile($q);
+            $this->assertNotNull($v);
+            $recovered = $digest->rank($v);
+            $this->assertNotNull($recovered);
+            $this->assertLessThanOrEqual(
+                0.005,
+                abs($recovered - $q),
+                "rank(quantile({$q})) = {$recovered}, off by " . abs($recovered - $q)
+            );
+        }
+    }
+
+    /**
+     * rank() estimates the true CDF of the sample within the same rank
+     * error tolerance the quantile tests pin — rank error is symmetric:
+     * |rank(x) - trueCDF(x)| is the same quantity quantile tests measure
+     * as |q - trueRank(quantile(q))|.
+     */
+    public function test_rank_error_against_exact_cdf(): void
+    {
+        mt_srand(1234);
+        [$digest, $sorted] = $this->build(fn () => mt_rand() / mt_getrandmax() * 1000.0);
+        $n = count($sorted);
+
+        // Pick values at known true CDF positions: the k-th smallest has
+        // true CDF ≈ k/n. rank() of that value should be within the
+        // digest's resolution.
+        foreach ([0.01, 0.25, 0.5, 0.75, 0.99] as $qFrac) {
+            $k = (int) round($qFrac * $n);
+            $x = $sorted[$k];
+            $trueCdf = $k / $n;
+            $estimated = $digest->rank($x);
+            $this->assertNotNull($estimated);
+            $err = abs($estimated - $trueCdf);
+            $this->assertLessThanOrEqual(
+                0.005,
+                $err,
+                sprintf('rank() error %.4f%% at trueCDF=%.3f exceeds 0.5%%', $err * 100, $trueCdf)
+            );
+        }
+    }
+
+    public function test_rank_constant_stream(): void
+    {
+        $d = new TDigest();
+        for ($i = 0; $i < 1000; $i++) {
+            $d->add(5.0);
+        }
+
+        // All values equal → min === max; rank of anything below is 0,
+        // at/above is 1. The 5.0 boundary hits the min early-return (0.0).
+        $this->assertSame(0.0, $d->rank(5.0));
+        $this->assertSame(1.0, $d->rank(5.0001));
+        $this->assertSame(0.0, $d->rank(4.9999));
+    }
+
+    // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
 

--- a/tests/Writers/CompactModeTest.php
+++ b/tests/Writers/CompactModeTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Exceptions\XlsxStreamException;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\BaseXlsxWriter;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+use ZipArchive;
+
+/**
+ * v3.3 compact mode (H1): opt-in `->compact()` emits rows and cells
+ * WITHOUT the optional r attributes (ECMA-376: c/@r and row/@r are
+ * optional; readers assign positions sequentially).
+ *
+ * The load-bearing proof is the TRANSFORM BYTE-ORACLE: for the same
+ * input, the compact writer's sheet XML must equal the classic
+ * writer's sheet XML with every ` r="A1"`-style attribute stripped —
+ * i.e. compact is the exact r-less projection of the classic path,
+ * not a reimplementation that could drift. Every cell-shape branch
+ * (strings incl. ws-preserve/numeric-preserve, int/float with and
+ * without column styles, null/'' placeholders, bool, DateTime,
+ * Stringable, styled rows incl. merged column-format styles, the
+ * preamble header row, sample-mode deferred preambles, multi-sheet)
+ * rides through the corpus below.
+ */
+class CompactModeTest extends TestCase
+{
+    /** @var list<string> */
+    private array $files = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->files as $f) {
+            @unlink($f);
+        }
+        $this->files = [];
+        parent::tearDown();
+    }
+
+    private function tmpFile(string $tag): string
+    {
+        $path = sys_get_temp_dir()."/kxs-compact-{$tag}-".uniqid('', true).'.xlsx';
+        $this->files[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Rich corpus exercising every emission branch, written with the
+     * exact same calls in both modes.
+     */
+    private function writeCorpus(string $path, bool $compact): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        if ($compact) {
+            $writer->compact();
+        }
+
+        $writer->withRandomAccessIndex(every: 100);
+        $writer->withColumnStats([1, 3]);
+        $writer->withColumnSketches([1, 3]);
+        $writer->setAutoColumnWidth(50);           // sample mode -> deferred preamble path
+        $writer->setColumnWidths([6 => 30]);
+        $writer->freezeFirstRow();
+        $writer->enableAutoFilter();
+        $writer->setHeaderStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF', 'bold' => true]);
+        $writer->setColumnFormat(3, BaseXlsxWriter::BUILTIN_NUMFMT_CURRENCY);
+        $writer->setColumnFormat(4, 'dd"."mm"."yyyy hh:mm', raw: true);
+
+        $writer->startFile(['id', 'ad', 'tutar', 'tarih', 'aktif', 'not']);
+
+        $red = $writer->registerRowStyle(['fill' => '#FFC7CE', 'color' => '#9C0006']);
+        $blue = $writer->registerRowStyle(['fill' => '#1F4E78', 'color' => '#FFFFFF', 'bold' => true]);
+
+        $base = new \DateTimeImmutable('2026-03-01 09:00:00');
+        $stringable = new class () {
+            public function __toString(): string
+            {
+                return '  stringable ws  ';
+            }
+        };
+
+        for ($i = 1; $i <= 600; $i++) {
+            $row = [
+                $i,
+                'müşteri <'.$i.'> & "özel"',
+                round($i * 1.37, 2),
+                $base->modify('+'.$i.' minutes'),
+                $i % 2 === 0,
+                'not-'.$i,
+            ];
+            if ($i % 7 === 0) {          // sparse: mid-row nulls
+                $row[1] = null;
+                $row[3] = null;
+            }
+            if ($i % 11 === 0) {         // empty strings
+                $row[2] = '';
+                $row[4] = '';
+            }
+            if ($i % 13 === 0) {         // numeric-string preservation + big int
+                $row[1] = '007';
+                $row[5] = '12345678901234567890';
+            }
+            if ($i % 17 === 0) {         // ws-preserve + stringable
+                $row[1] = '  boşluklu  ';
+                $row[5] = $stringable;
+            }
+            if ($i % 19 === 0) {         // short row (trailing columns absent)
+                $row = [$i, 'kısa'];
+            }
+
+            $style = $i % 5 === 0 ? ($i % 10 === 0 ? $blue : $red) : null;
+            $writer->writeRow($row, $style);
+        }
+
+        // Second sheet: different schema, clean formats (v3.2.2 rule:
+        // prepare BEFORE newSheet is safe — pending sample finalizes).
+        $writer->clearColumnFormats();
+        $writer->setHeaderStyle(['fill' => '#375623', 'color' => '#FFFFFF']);
+        $writer->newSheet('Özet', ['ay', 'toplam']);
+        for ($m = 1; $m <= 12; $m++) {
+            $writer->writeRow([$m, $m * 1000.5]);
+        }
+
+        $writer->finishFile();
+    }
+
+    /** The PoC transform: strip cell refs, then row refs. */
+    private function stripRefs(string $sheetXml): string
+    {
+        $out = preg_replace('~ r="[A-Z]+\d+"~', '', $sheetXml);
+
+        return preg_replace('~<row r="\d+"~', '<row', $out);
+    }
+
+    private function sheetXml(string $path, int $sheet): string
+    {
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($path));
+        $xml = $zip->getFromName("xl/worksheets/sheet{$sheet}.xml");
+        $zip->close();
+        $this->assertNotFalse($xml, "sheet{$sheet}.xml missing in {$path}");
+
+        return $xml;
+    }
+
+    public function test_compact_output_is_the_exact_r_less_projection_of_classic_output(): void
+    {
+        $classic = $this->tmpFile('classic');
+        $compact = $this->tmpFile('compact');
+        $this->writeCorpus($classic, compact: false);
+        $this->writeCorpus($compact, compact: true);
+
+        foreach ([1, 2] as $sheet) {
+            $expected = $this->stripRefs($this->sheetXml($classic, $sheet));
+            $actual = $this->sheetXml($compact, $sheet);
+            $this->assertSame($expected, $actual, "sheet{$sheet}: compact XML is not the exact r-less projection");
+        }
+    }
+
+    public function test_reader_reads_compact_file_identically_to_classic(): void
+    {
+        $classic = $this->tmpFile('classic-r');
+        $compact = $this->tmpFile('compact-r');
+        $this->writeCorpus($classic, compact: false);
+        $this->writeCorpus($compact, compact: true);
+
+        $rA = StreamingXlsxReader::fromFile($classic);
+        $rB = StreamingXlsxReader::fromFile($compact);
+        foreach ([0, 1] as $idx) {
+            $rA->onSheetIndex($idx);
+            $rB->onSheetIndex($idx);
+            $a = iterator_to_array($rA->rows(), false);
+            $b = iterator_to_array($rB->rows(), false);
+            $this->assertSame($a, $b, "sheet index {$idx} rows differ between classic and compact");
+            $this->assertGreaterThan(2, count($a));
+        }
+    }
+
+    public function test_sidecar_random_access_works_on_compact_files(): void
+    {
+        $path = $this->tmpFile('sidecar');
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->compact();
+        $writer->withRandomAccessIndex(every: 500);
+        $writer->withColumnStats([1, 2]);
+        $writer->withColumnSketches([1, 2]);
+        $writer->startFile(['id', 'amount']);
+        for ($i = 1; $i <= 5000; $i++) {
+            $writer->writeRow([$i, 2 * $i]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($path);
+        $this->assertSame(5001, $reader->rowCount());
+
+        $row = $reader->rowAt(4001);            // sync-point seek into an r-less block
+        $this->assertNotNull($row);
+        $this->assertSame('4000', (string) $row[0]);
+
+        $stats = $reader->columnStats(1);
+        $this->assertNotNull($stats);
+        $this->assertSame(5000, $stats['count']);
+        $this->assertSame(5000.0, $stats['max']);
+        $this->assertSame('asc', $stats['sorted']);
+
+        $this->assertSame(5000.0, $reader->quantile(1, 1.0)); // exact max from TDIG
+
+        $hits = iterator_to_array($reader->rowsWhere(1, 'between', 4000, 4002), true);
+        $this->assertSame([4001, 4002, 4003], array_keys($hits));
+    }
+
+    public function test_compact_after_start_file_throws(): void
+    {
+        $path = $this->tmpFile('late');
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->startFile(['a']);
+
+        $this->expectException(XlsxStreamException::class);
+        $writer->compact();
+    }
+
+    public function test_sparse_rows_keep_positions_in_compact_mode(): void
+    {
+        $path = $this->tmpFile('sparse');
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->compact();
+        $writer->startFile(['a', 'b', 'c', 'd']);
+        $writer->writeRow([1, null, 3, null]);   // mid + trailing null
+        $writer->writeRow([null, '', null, 4]);  // leading null + empty string
+        $writer->writeRow([5]);                  // short row
+        $writer->finishFile();
+
+        $rows = iterator_to_array(StreamingXlsxReader::fromFile($path)->rows(skip: 1), false);
+        $this->assertSame(['1', '', '3', ''], $rows[0]);
+        $this->assertSame(['', '', '', '4'], $rows[1]);
+        $this->assertSame(['5'], $rows[2]);
+    }
+
+    public function test_compact_with_sample_auto_width_keeps_user_widths(): void
+    {
+        $path = $this->tmpFile('widths');
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->compact();
+        $writer->setAutoColumnWidth(10);
+        $writer->setColumnWidths([2 => 33]);
+        $writer->startFile(['x', 'y']);
+        for ($i = 0; $i < 20; $i++) {
+            $writer->writeRow(['aa', str_repeat('uzun', 10)]);
+        }
+        $writer->finishFile();
+
+        $xml = $this->sheetXml($path, 1);
+        $this->assertStringContainsString('<col min="2" max="2" width="33"', $xml);
+        $this->assertStringNotContainsString(' r="', preg_replace('~<worksheet[^>]*>~', '', $xml));
+    }
+}

--- a/tests/Writers/GroupBoundarySyncTest.php
+++ b/tests/Writers/GroupBoundarySyncTest.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Contracts\Source;
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Sources\LocalFileSource;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/** Read-filter that tallies every compressed byte the reader pulls. */
+class GroupSyncByteCounter extends \php_user_filter
+{
+    public static int $bytes = 0;
+
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            self::$bytes += $bucket->datalen;
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+}
+
+/**
+ * D1 — syncAtGroupBoundaries(): align the writer's ZLIB_FULL_FLUSH sync
+ * points (= index block boundaries) to GROUP changes, so every index
+ * block holds exactly one group. groupStats() already folds a
+ * group-pure block straight from the sidecar's per-block aggregates
+ * without reading a row (foldGroupStatsFor's stats path); group-aligned
+ * blocks make EVERY block pure, so a grouped aggregate reads ZERO rows.
+ *
+ * The sheet's decompressed bytes are unchanged (flush positions move,
+ * XML content does not); only where deflate flushes and where the sidecar
+ * records sync points differ. Default (no group sync) stays byte-identical.
+ */
+class GroupBoundarySyncTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-groupsync-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    /**
+     * 2000 rows in ascending groups of 137 (irregular vs any every-N
+     * block size). Large sync period so WITHOUT group sync the whole
+     * sheet is one mixed block; WITH it each group is its own pure block.
+     */
+    private function writeFixture(string $path, bool $groupSync): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($path));
+        $writer->withRandomAccessIndex(every: 100000); // effectively never by row count
+        $writer->withColumnStats([1, 2]);
+        $writer->setBufferFlushInterval(200);
+        if ($groupSync) {
+            $writer->syncAtGroupBoundaries(1);
+        }
+        $writer->startFile(['grp', 'amount']);
+        for ($i = 1; $i <= 2000; $i++) {
+            $writer->writeRow([intdiv($i - 1, 137), $i * 1.0]);
+        }
+        $writer->finishFile();
+    }
+
+    private function makeSpy(string $path): object
+    {
+        return new class (new LocalFileSource($path)) implements Source {
+            public int $streamCalls = 0;
+
+            public function __construct(private LocalFileSource $inner) {}
+
+            public function size(): int
+            {
+                return $this->inner->size();
+            }
+
+            public function range(int $offset, int $length): string
+            {
+                return $this->inner->range($offset, $length);
+            }
+
+            public function streamFrom(int $offset, ?int $length = null)
+            {
+                $this->streamCalls++;
+
+                return $this->inner->streamFrom($offset, $length);
+            }
+
+            public function close(): void
+            {
+                $this->inner->close();
+            }
+        };
+    }
+
+    /** Brute-force GROUP BY grp: [grp => [sum, count, min, max]]. */
+    private function oracle(): array
+    {
+        $g = [];
+        for ($i = 1; $i <= 2000; $i++) {
+            $key = intdiv($i - 1, 137);
+            $v = $i * 1.0;
+            if (! isset($g[$key])) {
+                $g[$key] = ['sum' => 0.0, 'count' => 0, 'min' => $v, 'max' => $v];
+            }
+            $g[$key]['sum'] += $v;
+            $g[$key]['count']++;
+            $g[$key]['min'] = min($g[$key]['min'], $v);
+            $g[$key]['max'] = max($g[$key]['max'], $v);
+        }
+
+        return $g;
+    }
+
+    public function test_group_aligned_blocks_answer_group_stats_from_the_sidecar(): void
+    {
+        $this->writeFixture($this->testFile, groupSync: true);
+
+        $spy = $this->makeSpy($this->testFile);
+        $reader = StreamingXlsxReader::from($spy);
+        $reader->rowCount();       // warm index (uses range(), not streamFrom)
+        $spy->streamCalls = 0;
+
+        $stats = $reader->groupStats(1, 2);
+
+        // Every GROUP block folds straight from the sidecar; only block 0
+        // (the header rides in it) is ever scanned -> exactly one stream,
+        // no matter how many groups there are.
+        $this->assertSame(1, $spy->streamCalls, 'only the header block should be scanned');
+
+        // ...and the answer is exact.
+        $oracle = $this->oracle();
+        $this->assertCount(count($oracle), $stats);
+        foreach ($stats as $row) {
+            $g = (int) $row['group'];
+            $this->assertArrayHasKey($g, $oracle);
+            $this->assertSame($oracle[$g]['count'], $row['count'], "count for group {$g}");
+            $this->assertEqualsWithDelta($oracle[$g]['sum'], $row['sum'], 1e-6, "sum for group {$g}");
+            $this->assertEqualsWithDelta($oracle[$g]['min'], $row['min'], 1e-6, "min for group {$g}");
+            $this->assertEqualsWithDelta($oracle[$g]['max'], $row['max'], 1e-6, "max for group {$g}");
+        }
+        $reader->close();
+    }
+
+    /** Compressed bytes the reader pulls while answering groupStats(). */
+    private function groupStatsBytes(string $path): int
+    {
+        $inner = new LocalFileSource($path);
+        $source = new class ($inner) implements Source {
+            public function __construct(private LocalFileSource $inner) {}
+
+            public function size(): int
+            {
+                return $this->inner->size();
+            }
+
+            public function range(int $offset, int $length): string
+            {
+                return $this->inner->range($offset, $length);
+            }
+
+            public function streamFrom(int $offset, ?int $length = null)
+            {
+                $h = $this->inner->streamFrom($offset, $length);
+                stream_filter_append($h, 'group_sync_byte_counter', STREAM_FILTER_READ);
+
+                return $h;
+            }
+
+            public function close(): void
+            {
+                $this->inner->close();
+            }
+        };
+
+        $reader = StreamingXlsxReader::from($source);
+        $reader->rowCount();
+        GroupSyncByteCounter::$bytes = 0;
+        $reader->groupStats(1, 2);
+        $reader->close();
+
+        return GroupSyncByteCounter::$bytes;
+    }
+
+    public function test_group_sync_reads_far_fewer_bytes_than_without(): void
+    {
+        stream_filter_register('group_sync_byte_counter', GroupSyncByteCounter::class);
+
+        $synced = $this->testFile;
+        $plain = $this->testFile.'.plain.xlsx';
+        $this->writeFixture($synced, groupSync: true);
+        $this->writeFixture($plain, groupSync: false);
+
+        try {
+            $syncedBytes = $this->groupStatsBytes($synced);
+            $plainBytes = $this->groupStatsBytes($plain);
+
+            // Group sync scans only the small header block; without it the
+            // one mixed block IS the whole sheet, so groupStats tokenizes
+            // every row. Expect a large reduction, not a marginal one.
+            $this->assertGreaterThan(0, $syncedBytes);
+            $this->assertLessThan($plainBytes / 2, $syncedBytes, 'group sync must read far fewer compressed bytes');
+        } finally {
+            @unlink($plain);
+        }
+    }
+
+    public function test_reader_reads_group_synced_file_row_for_row(): void
+    {
+        $this->writeFixture($this->testFile, groupSync: true);
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $rows = iterator_to_array($reader->rows(skip: 1), false);
+        $this->assertCount(2000, $rows);
+        $this->assertSame(['0', '1'], $rows[0]);              // i=1: grp 0, amount 1
+        $this->assertSame((string) intdiv(2000 - 1, 137), $rows[1999][0]);
+        $reader->close();
+    }
+
+    public function test_enables_random_access_index(): void
+    {
+        // syncAtGroupBoundaries without an explicit withRandomAccessIndex
+        // must still produce a queryable sidecar (it enables the index).
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->withColumnStats([1, 2]);
+        $writer->syncAtGroupBoundaries(1);
+        $writer->startFile(['grp', 'amount']);
+        for ($i = 1; $i <= 500; $i++) {
+            $writer->writeRow([intdiv($i - 1, 50), $i * 1.0]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $this->assertNotNull($reader->columnStats(2));
+        $this->assertSame(10, count($reader->groupStats(1, 2)));
+        $reader->close();
+    }
+
+    public function test_throws_after_start_file(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['grp', 'amount']);
+
+        $this->expectException(\Kolay\XlsxStream\Exceptions\XlsxStreamException::class);
+        $writer->syncAtGroupBoundaries(1);
+    }
+}

--- a/tests/Writers/QueryablePresetTest.php
+++ b/tests/Writers/QueryablePresetTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Kolay\XlsxStream\Tests\Writers;
+
+use Kolay\XlsxStream\Readers\StreamingXlsxReader;
+use Kolay\XlsxStream\Sinks\FileSink;
+use Kolay\XlsxStream\Tests\TestCase;
+use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+
+/**
+ * E3 — queryable(): one call that turns on the whole query stack
+ * (random-access index + column zone maps + sketches) for a set of
+ * columns, so the common "make this export queryable" setup is a
+ * one-liner instead of three chained calls.
+ */
+class QueryablePresetTest extends TestCase
+{
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->testFile = sys_get_temp_dir().'/kxs-queryable-'.uniqid('', true).'.xlsx';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testFile);
+        parent::tearDown();
+    }
+
+    public function test_queryable_enables_index_stats_and_sketches(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->queryable([1, 2]);
+        $writer->startFile(['id', 'amount']);
+        for ($i = 1; $i <= 1000; $i++) {
+            $writer->writeRow([$i, $i * 2.5]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+
+        // Zone maps (columnStats) + point pruning (rowsWhere) + sketches
+        // (quantile) must all be available — the three subsystems queryable()
+        // switched on.
+        $this->assertNotNull($reader->columnStats(2));
+        $this->assertSame(1000, $reader->columnStats(1)['count']);
+        $this->assertCount(1, iterator_to_array($reader->rowsWhere(1, '=', 500)));
+        $this->assertNotNull($reader->quantile(2, 0.5)); // sketch present
+        $reader->close();
+    }
+
+    public function test_queryable_matches_the_three_separate_calls_byte_for_byte(): void
+    {
+        $preset = $this->testFile;
+        $manual = $this->testFile.'.manual.xlsx';
+
+        $write = function (string $path, bool $usePreset): void {
+            $w = new SinkableXlsxWriter(new FileSink($path));
+            if ($usePreset) {
+                $w->queryable([1, 2], every: 250);
+            } else {
+                $w->withRandomAccessIndex(every: 250)->withColumnStats([1, 2])->withColumnSketches([1, 2]);
+            }
+            $w->setBufferFlushInterval(250);
+            $w->startFile(['id', 'amount']);
+            for ($i = 1; $i <= 1000; $i++) {
+                $w->writeRow([$i, $i * 2.5]);
+            }
+            $w->finishFile();
+        };
+
+        try {
+            $write($preset, true);
+            $write($manual, false);
+
+            // Same configuration => byte-identical file.
+            $this->assertSame(
+                hash_file('sha256', $manual),
+                hash_file('sha256', $preset),
+                'queryable() preset must equal the three explicit calls'
+            );
+        } finally {
+            @unlink($manual);
+        }
+    }
+
+    public function test_queryable_without_sketches(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->queryable([1], withSketches: false);
+        $writer->startFile(['id']);
+        for ($i = 1; $i <= 300; $i++) {
+            $writer->writeRow([$i]);
+        }
+        $writer->finishFile();
+
+        $reader = StreamingXlsxReader::fromFile($this->testFile);
+        $this->assertNotNull($reader->columnStats(1));   // stats on
+        $this->assertNull($reader->quantile(1, 0.5));     // sketches off
+        $reader->close();
+    }
+
+    public function test_queryable_throws_after_start(): void
+    {
+        $writer = new SinkableXlsxWriter(new FileSink($this->testFile));
+        $writer->startFile(['id']);
+
+        $this->expectException(\Kolay\XlsxStream\Exceptions\XlsxStreamException::class);
+        $writer->queryable([1]);
+    }
+}

--- a/tests/Writers/QueryablePresetTest.php
+++ b/tests/Writers/QueryablePresetTest.php
@@ -6,6 +6,7 @@ use Kolay\XlsxStream\Readers\StreamingXlsxReader;
 use Kolay\XlsxStream\Sinks\FileSink;
 use Kolay\XlsxStream\Tests\TestCase;
 use Kolay\XlsxStream\Writers\SinkableXlsxWriter;
+use ZipArchive;
 
 /**
  * E3 — queryable(): one call that turns on the whole query stack
@@ -75,12 +76,29 @@ class QueryablePresetTest extends TestCase
             $write($preset, true);
             $write($manual, false);
 
-            // Same configuration => byte-identical file.
-            $this->assertSame(
-                hash_file('sha256', $manual),
-                hash_file('sha256', $preset),
-                'queryable() preset must equal the three explicit calls'
-            );
+            // Compare ZIP ENTRY CONTENTS, not the whole-file bytes: the ZIP
+            // local/central headers carry a DOS timestamp from time(), so two
+            // separate writes straddling a second boundary differ in metadata
+            // even for identical content. What "queryable() == the three
+            // calls" actually claims is that every produced entry — the sheet,
+            // styles, workbook, AND the xl/_kxs/index.bin sidecar (index +
+            // zone maps + sketches) — is byte-identical.
+            $za = new ZipArchive();
+            $zb = new ZipArchive();
+            $this->assertTrue($za->open($preset));
+            $this->assertTrue($zb->open($manual));
+
+            $this->assertSame($za->numFiles, $zb->numFiles, 'entry count differs');
+            for ($i = 0; $i < $za->numFiles; $i++) {
+                $name = $za->getNameIndex($i);
+                $this->assertSame(
+                    hash('sha256', (string) $za->getFromName($name)),
+                    hash('sha256', (string) $zb->getFromName($name)),
+                    "entry {$name} differs between queryable() and the three explicit calls"
+                );
+            }
+            $za->close();
+            $zb->close();
         } finally {
             @unlink($manual);
         }

--- a/tests/Writers/RealS3Test.php
+++ b/tests/Writers/RealS3Test.php
@@ -151,4 +151,53 @@ class RealS3Test extends TestCase
         fwrite(STDERR, "\n✓ File size: " . number_format($result['ContentLength']) . " bytes");
         fwrite(STDERR, "\n✓ Location: s3://{$bucket}/{$key}\n");
     }
+
+    /**
+     * Bounded-memory regression guard for the default (synchronous) S3
+     * sink. Writing 1M rows produces a multi-part (>8 MB) upload, so the
+     * part-boundary GC path is exercised. Peak memory must stay flat at
+     * ~the part-buffer working set regardless of row count — before the
+     * fix the AWS SDK's async promise/command graph held every dispatched
+     * part's body and memory climbed toward the whole file (≈54 MB at 1M,
+     * unbounded beyond). The default concurrency=1 + per-part
+     * gc_collect_cycles() keeps it O(1).
+     */
+    public function test_s3_write_memory_stays_bounded_regardless_of_row_count()
+    {
+        $bucket = getenv('AWS_BUCKET');
+        $key = 'tests/mem-' . uniqid() . '.xlsx';
+
+        $sink = new S3MultipartSink($this->s3Client, $bucket, $key); // default concurrency=1
+        $writer = new SinkableXlsxWriter($sink);
+        $writer->setCompressionLevel(1)->setBufferFlushInterval(10000);
+
+        gc_collect_cycles();
+        memory_reset_peak_usage();
+        $before = memory_get_usage(true);
+
+        $writer->startFile(['ID', 'Name', 'Email', 'Department', 'Salary', 'Date', 'Status', 'Notes']);
+        for ($i = 1; $i <= 1_000_000; $i++) {
+            $writer->writeRow([
+                $i, 'Employee' . ($i % 100), 'emp' . ($i % 100) . '@company.com',
+                'Dept' . ($i % 10), 50000 + ($i % 50) * 1000, '2026-05-09',
+                'Status' . ($i % 5), 'Standard notes for employee record',
+            ]);
+        }
+        $writer->finishFile();
+
+        $peakDelta = (memory_get_peak_usage(true) - $before) / 1024 / 1024;
+
+        // Cleanup before asserting so a failure still removes the object.
+        $this->s3Client->deleteObject(['Bucket' => $bucket, 'Key' => $key]);
+
+        fwrite(STDERR, "\n✓ 1M-row S3 write peak memory delta: " . round($peakDelta, 1) . " MB\n");
+
+        // Fixed path holds ~30 MB; the pre-fix ratchet exceeded ~50 MB at 1M
+        // and grew with the file. 45 MB cleanly separates the two.
+        $this->assertLessThan(
+            45,
+            $peakDelta,
+            "S3 write peak memory ({$peakDelta} MB) grew with row count — the multipart sink is leaking part bodies again."
+        );
+    }
 }

--- a/tests/Writers/S3MultipartSinkParallelTest.php
+++ b/tests/Writers/S3MultipartSinkParallelTest.php
@@ -191,11 +191,9 @@ class S3MultipartSinkParallelTest extends TestCase
     {
         $s3 = $this->mockS3();
 
-        $s3->shouldReceive('uploadPartAsync')
-            ->once()
-            ->andReturn(new RejectedPromise(new \RuntimeException('boom')));
-
-        // Re-dispatch also fails -> first-error-wins failure.
+        // Synchronous default (concurrency 1): uploadPart is called directly
+        // and its throw is recorded as the failure (the SDK's own retry
+        // middleware already handled transience — no manual re-dispatch here).
         $s3->shouldReceive('uploadPart')
             ->once()
             ->andThrow(new \RuntimeException('still failing'));
@@ -206,11 +204,10 @@ class S3MultipartSinkParallelTest extends TestCase
             ->andReturn([]);
 
         $sink = new S3MultipartSink($s3, 'bucket', 'key.xlsx', self::PART, [], 1);
-        $sink->write(str_repeat('d', self::PART)); // dispatches part 1
+        $sink->write(str_repeat('d', self::PART)); // uploads part 1 -> throws -> failure recorded
 
         try {
-            // Window (size 1) is full: this waits on part 1, discovers the
-            // failure, aborts and throws.
+            // The next write() sees the recorded failure, aborts and throws.
             $sink->write(str_repeat('d', self::PART));
             $this->fail('Expected S3Exception was not thrown');
         } catch (S3Exception $e) {
@@ -300,19 +297,15 @@ class S3MultipartSinkParallelTest extends TestCase
         $s3 = $this->mockS3();
 
         $events = [];
-        $s3->shouldReceive('uploadPartAsync')
+        // concurrency 1 = synchronous uploadPart: each part fully uploads
+        // (call returns) before the next is sent — inherently sequential.
+        $s3->shouldReceive('uploadPart')
             ->times(3)
             ->andReturnUsing(function (array $args) use (&$events) {
                 $n = $args['PartNumber'];
-                $events[] = "dispatch-{$n}";
+                $events[] = "part-{$n}";
 
-                $promise = null;
-                $promise = new Promise(function () use (&$promise, &$events, $n) {
-                    $events[] = "complete-{$n}";
-                    $promise->resolve(['ETag' => 'etag-' . $n]);
-                });
-
-                return $promise;
+                return ['ETag' => 'etag-' . $n];
             });
 
         $s3->shouldReceive('completeMultipartUpload')
@@ -327,15 +320,11 @@ class S3MultipartSinkParallelTest extends TestCase
         $sink->write(str_repeat('g', self::PART * 3));
         $sink->close();
 
-        // Same S3 request sequence as the pre-3.2 blocking implementation:
-        // each part fully completes before the next one is dispatched.
+        // Parts upload in strict order, each finishing before the next.
         $this->assertSame([
-            'dispatch-1',
-            'complete-1',
-            'dispatch-2',
-            'complete-2',
-            'dispatch-3',
-            'complete-3',
+            'part-1',
+            'part-2',
+            'part-3',
             'complete-upload',
         ], $events);
     }

--- a/tests/Writers/SinkTest.php
+++ b/tests/Writers/SinkTest.php
@@ -120,13 +120,14 @@ class SinkTest extends TestCase
             ->once()
             ->andReturn(['UploadId' => 'test-upload-id']);
         
-        $s3Client->shouldReceive('uploadPartAsync')
+        // Default sink is synchronous (concurrency 1) -> uploadPart, not async.
+        $s3Client->shouldReceive('uploadPart')
             ->once()
             ->with(Mockery::on(function ($args) {
                 return $args['PartNumber'] === 1
                     && strlen($args['Body']) === 5 * 1024 * 1024;
             }))
-            ->andReturn(new \GuzzleHttp\Promise\FulfilledPromise(['ETag' => 'etag-1']));
+            ->andReturn(['ETag' => 'etag-1']);
         
         $s3Client->shouldReceive('completeMultipartUpload')
             ->once()

--- a/tests/Writers/SinkTest.php
+++ b/tests/Writers/SinkTest.php
@@ -149,6 +149,46 @@ class SinkTest extends TestCase
         $this->assertEquals(5 * 1024 * 1024, $sink->getBytesWritten());
     }
     
+    public function test_verify_parts_attaches_content_md5()
+    {
+        $chunk = str_repeat('a', 5 * 1024 * 1024);
+        $expectedMd5 = base64_encode(md5($chunk, true));
+
+        $s3Client = Mockery::mock(S3Client::class);
+        $s3Client->shouldReceive('createMultipartUpload')->once()
+            ->andReturn(['UploadId' => 'test-upload-id']);
+        $s3Client->shouldReceive('uploadPart')->once()
+            ->with(Mockery::on(fn ($args) => ($args['ContentMD5'] ?? null) === $expectedMd5))
+            ->andReturn(['ETag' => 'etag-1']);
+        $s3Client->shouldReceive('completeMultipartUpload')->once()->andReturn([]);
+
+        // verifyParts = true (7th arg)
+        $sink = new S3MultipartSink($s3Client, 'b', 'k.xlsx', 5 * 1024 * 1024, [], 1, true);
+        $sink->write($chunk);
+        $sink->close();
+
+        $this->assertSame(5 * 1024 * 1024, $sink->getBytesWritten());
+    }
+
+    public function test_parts_carry_no_content_md5_by_default()
+    {
+        $chunk = str_repeat('b', 5 * 1024 * 1024);
+
+        $s3Client = Mockery::mock(S3Client::class);
+        $s3Client->shouldReceive('createMultipartUpload')->once()
+            ->andReturn(['UploadId' => 'test-upload-id']);
+        $s3Client->shouldReceive('uploadPart')->once()
+            ->with(Mockery::on(fn ($args) => ! isset($args['ContentMD5'])))
+            ->andReturn(['ETag' => 'etag-1']);
+        $s3Client->shouldReceive('completeMultipartUpload')->once()->andReturn([]);
+
+        $sink = new S3MultipartSink($s3Client, 'b', 'k.xlsx', 5 * 1024 * 1024); // default: verifyParts off
+        $sink->write($chunk);
+        $sink->close();
+
+        $this->assertSame(5 * 1024 * 1024, $sink->getBytesWritten());
+    }
+
     public function test_s3_multipart_sink_aborts_on_error()
     {
         $s3Client = Mockery::mock(S3Client::class);

--- a/tests/compat/external_readers_roundtrip.php
+++ b/tests/compat/external_readers_roundtrip.php
@@ -7,11 +7,14 @@
  * libs are not present in the regular CI matrix, so loading them
  * inside a phpunit class would fail the suite.
  *
- * Two assertions:
- *   1. PhpSpreadsheet can open a file produced by SinkableXlsxWriter
- *      (with and without random-access index).
+ * Assertions:
+ *   1. PhpSpreadsheet + OpenSpout can open a file produced by
+ *      SinkableXlsxWriter (with and without random-access index).
  *   2. StreamingXlsxReader can read a file produced by PhpSpreadsheet
  *      (which uses xl/sharedStrings.xml — the external-XLSX path).
+ *   3. Both external readers open a COMPACT (r-less) file and assign
+ *      cell positions sequentially — a mid-row null does not shift
+ *      later columns (the compact-mode invariant).
  *
  * Exits non-zero on any failure; intended to be run from the workflow.
  */
@@ -156,6 +159,65 @@ try {
     }
 } catch (Throwable $e) {
     fail($failures, 'kxs→OpenSpout', $e->getMessage());
+}
+
+// ---------------------------------------------------------------
+// Test 5 & 6: kolay/xlsx-stream COMPACT (r-less cells) → external readers
+// Compact mode omits the optional c/@r and row/@r attributes; external
+// readers MUST assign cell positions sequentially, with the empty <c/>
+// placeholder carrying the position. The load-bearing risk: a mid-row
+// null must NOT shift later columns left. Row 100 is [100, <null>, 300,
+// false] — its col C (300) and col D (false) must stay put.
+// ---------------------------------------------------------------
+$kxsCompact = $tmp.'/kxs-compact.xlsx';
+$writer = new SinkableXlsxWriter(new FileSink($kxsCompact));
+$writer->compact();
+$writer->startFile(['a', 'b', 'c', 'd']);
+for ($i = 1; $i <= 200; $i++) {
+    $row = $i === 100 ? [100, null, 300, false] : [$i, "name-{$i}", $i * 2.5, $i % 2 === 0];
+    $writer->writeRow($row);
+}
+$writer->finishFile();
+
+try {
+    $book = IOFactory::load($kxsCompact);
+    $sheet = $book->getActiveSheet();
+    $rowCount = $sheet->getHighestDataRow();
+    $cAfterNull = (string) $sheet->getCell('C101')->getValue();   // data row 100 -> sheet row 101
+    if ($rowCount !== 201) {
+        fail($failures, 'kxs-compact→PhpSpreadsheet rowcount', "expected 201, got {$rowCount}");
+    } elseif ($cAfterNull !== '300') {
+        fail($failures, 'kxs-compact→PhpSpreadsheet position', "null shifted columns: C101='{$cAfterNull}' (expected 300)");
+    } else {
+        pass('kxs-compact→PhpSpreadsheet (r-less cells, mid-null keeps column position)');
+    }
+} catch (Throwable $e) {
+    fail($failures, 'kxs-compact→PhpSpreadsheet', $e->getMessage());
+}
+
+try {
+    $reader = new OpenSpoutReader();
+    $reader->open($kxsCompact);
+    $count = 0;
+    $row100 = null;
+    foreach ($reader->getSheetIterator() as $sheet) {
+        foreach ($sheet->getRowIterator() as $row) {
+            $count++;
+            if ($count === 101) {                 // header + 100 data rows
+                $row100 = $row->toArray();
+            }
+        }
+    }
+    $reader->close();
+    if ($count !== 201) {
+        fail($failures, 'kxs-compact→OpenSpout rowcount', "expected 201, got {$count}");
+    } elseif ($row100 === null || (int) ($row100[2] ?? 0) !== 300) {
+        fail($failures, 'kxs-compact→OpenSpout position', 'null shifted columns: row100='.json_encode($row100));
+    } else {
+        pass('kxs-compact→OpenSpout (r-less cells, mid-null keeps column position)');
+    }
+} catch (Throwable $e) {
+    fail($failures, 'kxs-compact→OpenSpout', $e->getMessage());
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
# What

v3.3 — a real query engine on top of the born-indexed sidecar, writer &
DX ergonomics, integrity verification, and a critical S3 write-memory fix.
**No breaking changes**: the base `Source` contract is unchanged and
classic writer output is byte-identical (compact mode and group-aligned
blocks are opt-in). One behavioral change — the S3 sink defaults to
synchronous uploads; see UPGRADE.md.

### Query engine
- `rowsWhereAll([...])` — multi-predicate AND, intersecting each
  predicate's surviving zone-map blocks (two differently-clustered
  columns read far fewer blocks than either alone).
- `estimatedRows()` / `explain()` — zero-I/O selectivity + query plans
  (hard zone-map upper bound + t-digest estimate; `{strategy,
  candidateBlocks, runs, estimatedRows, estimatedBytes}`).
- `topRows(col, k, desc)` — indexed "ORDER BY … LIMIT" (one seek on a
  sorted column; O(k) heap otherwise).
- `sampleRows(k, seed)` — uniform random sample via the index (≈k block
  reads, not a full scan); unbiasedness chi-square-gated.
- Column addressing by header name across the whole query surface.
- `Readers\Bucket::year()/month()/day()` for date `groupStats`.

### Writer & DX
- `queryable([...])` — index + zone maps + sketches in one call.
- `compact()` — opt-in r-less cells: ~52–62% smaller compressed sheets;
  writing/reading also faster. Byte-oracle-pinned as the exact r-less
  projection of classic output; classic byte-identical when off. Opens
  in Excel/LibreOffice/Numbers; read by PhpSpreadsheet 5.8 & OpenSpout
  4.28 (CI-verified).
- `syncAtGroupBoundaries(col)` — align blocks to groups → `groupStats`
  folds from the sidecar, reads only the header block.
- `onFullScan()` — hook fired when a query can't push down.

### Integrity
- `verify()` — block-granularity CRC check against the writer's SCRC
  pins; names the block that went bad. O(1) memory, one inflate pass.
- `new S3MultipartSink(..., verifyParts: true)` — S3 verifies each
  part's Content-MD5 and rejects a corrupted one.

### Fixed — S3 multipart writes are now O(1) memory
The parallel (async) upload path leaked: the AWS SDK's promise/command
graph retained each part's body, so S3 write memory grew with row count
(~130 MB at 3M rows, ≈ the whole file — unbounded beyond), silently
breaking the streaming-to-S3 memory promise. Uploads now default to
synchronous and release each part as it lands — flat ~part-size (~30 MB
peak on a 3M-row write) regardless of file size. Parallel uploads remain
an opt-in (`concurrency > 1`) for high-latency links, now GC-bounded.

## How it was verified
- Red-first tests throughout; **604 tests / 7541 assertions**, PHPStan
  clean, Pint clean.
- Byte-oracle for compact (== classic r-stripped) + classic output
  byte-identical (git-stash A/B, sha256).
- S3 O(1) proven on a real bucket: 3M-row write 130 MB → flat ~30 MB;
  a 500k-row multipart write is byte-identical to a local write at every
  ZIP content entry (GC between parts does not corrupt).
- Bench (cold machine): writer ~297K rows/s / 6 MB, read ~127K rows/s,
  rowAt/findRow/rowsWhere/groupStats at parity with 3.2 — no regression.
- Whole query surface parity local vs real S3 (HTTP Range GETs).